### PR TITLE
A required parameter cannot follow an optional parameter.

### DIFF
--- a/README.md
+++ b/README.md
@@ -364,7 +364,7 @@ The `connect` function is used to establish a Bluetooth Low Energy connection to
 
 ```typescript
 // Callback-based usage
-connect(peripheralUuid: string, options?: object, callback?: (error?: Error, peripheral: Peripheral) => void): void;
+connect(peripheralUuid: string, options?: object, callback?: (peripheral: Peripheral, error?: Error) => void): void;
 
 // Promise-based usage
 connectAsync(peripheralUuid: string, options?: object): Promise<Peripheral>;
@@ -384,7 +384,7 @@ The `connect` function initiates a connection to a BLE peripheral. The function 
 const noble = require('@stoprocent/noble');
 
 // Using callback
-noble.connect('1234567890abcdef', {}, (error, peripheral) => {
+noble.connect('1234567890abcdef', {}, (peripheral, error) => {
   if (error) {
     console.error('Connection error:', error);
   } else {

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,7 +25,7 @@ export declare function startScanning(serviceUUIDs?: string[], allowDuplicates?:
 export declare function startScanningAsync(serviceUUIDs?: string[], allowDuplicates?: boolean): Promise<void>;
 export declare function stopScanning(callback?: () => void): void;
 export declare function stopScanningAsync(): Promise<void>;
-export declare function connect(peripheralUuid: string, options?: object, callback?: (error?: Error, peripheral: Peripheral) => void): void;
+export declare function connect(peripheralUuid: string, options?: object, callback?: (peripheral: Peripheral, error?: Error) => void): void;
 export declare function connectAsync(peripheralUuid: string, options?: object): Promise<Peripheral>;
 export declare function cancelConnect(peripheralUuid: string, options?: object): void;
 export declare function reset(): void;


### PR DESCRIPTION
Resolves this:

```
node_modules/@stoprocent/noble/index.d.ts:28:102 - error TS1016: A required parameter cannot follow an optional parameter.

28 export declare function connect(peripheralUuid: string, options?: object, callback?: (error?: Error, peripheral: Peripheral) => void): void;
                                                                                                        ~~~~~~~~~~
```