### PR TITLE
fix(win): check adapter for correct role

### DIFF
--- a/lib/win/src/radio_watcher.cc
+++ b/lib/win/src/radio_watcher.cc
@@ -80,7 +80,7 @@ winrt::fire_and_forget RadioWatcher::OnRadioChanged() {
             capabilities.centralRoleSupported = adapter.IsCentralRoleSupported();
 
             Radio bluetooth = nullptr;
-            if (radio.State() == RadioState::On && adapter.IsPeripheralRoleSupported()) {
+            if (radio.State() == RadioState::On && adapter.IsCentralRoleSupported()) {
                 bluetooth = radio;
             }
 


### PR DESCRIPTION
Was really confused why this fork was broken for me (and the abandonware one worked fine), and turns out this was checking for the wrong role on Windows (peripheral instead of central) so this PR fixes that.