### PR TITLE
WinRT disconnect fix

### DIFF
--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -418,13 +418,6 @@ void BLEManager::OnConnectionStatusChanged(BluetoothLEDevice device,
             peripheral.Disconnect();
             mNotifyMap.Remove(uuid);
             mEmit.Disconnected(uuid);
-            //clean up to ensure disconnect from Windows
-            for(auto const& cachedService : peripheral.cachedServices)
-            {
-                cachedService.second.service.Close();
-            }
-            peripheral.gattSession.value().Close();
-            peripheral.device.value().Close();
         }
     }
 }

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -413,9 +413,12 @@ void BLEManager::OnConnectionStatusChanged(BluetoothLEDevice device,
             return;
         }
         PeripheralWinrt& peripheral = mDeviceMap[uuid];
-        peripheral.Disconnect();
-        mNotifyMap.Remove(uuid);
-        mEmit.Disconnected(uuid);
+        if(peripheral.device.has_value() && &(peripheral.device.value()) == &device )
+        {
+            peripheral.Disconnect();
+            mNotifyMap.Remove(uuid);
+            mEmit.Disconnected(uuid);
+        }
     }
 }
 

--- a/lib/win/src/peripheral_winrt.cc
+++ b/lib/win/src/peripheral_winrt.cc
@@ -162,15 +162,27 @@ void PeripheralWinrt::Update(const int rssiValue, const BluetoothLEAdvertisement
 
 void PeripheralWinrt::Disconnect()
 {
-    cachedServices.clear();
-    if (gattSession.has_value() && maxPduSizeChangedToken)
+    //clean up to ensure disconnect from Windows
+    for(auto const& cachedService : cachedServices)
     {
-        gattSession->MaxPduSizeChanged(maxPduSizeChangedToken);
+        cachedService.second.service.Close();
     }
-    if (device.has_value() && connectionToken)
+    cachedServices.clear();
+    if (gattSession.has_value())
     {
+        if(maxPduSizeChangedToken)
+        {
+            gattSession->MaxPduSizeChanged(maxPduSizeChangedToken);
+        }
+        gattSession->Close();
+    }
+    if (device.has_value())
+    {
+        if(connectionToken)
+        {
+            device->ConnectionStatusChanged(connectionToken);
+        }
         device->Close();
-        device->ConnectionStatusChanged(connectionToken);
     }
     device = std::nullopt;
 }

--- a/lib/win/src/peripheral_winrt.h
+++ b/lib/win/src/peripheral_winrt.h
@@ -72,6 +72,7 @@ public:
     winrt::event_token connectionToken;
     std::optional<GattSession> gattSession;
     winrt::event_token maxPduSizeChangedToken;
+    std::unordered_map<winrt::guid, CachedService> cachedServices;
 
 private:
     void GetServiceFromDevice(winrt::guid serviceUuid,
@@ -82,6 +83,5 @@ private:
     void
     GetDescriptorFromCharacteristic(GattCharacteristic characteristic, winrt::guid descriptorUuid,
                                     std::function<void(std::optional<GattDescriptor>)> callback);
-    std::unordered_map<winrt::guid, CachedService> cachedServices;
     void ProcessServiceData(const BluetoothLEAdvertisementDataSection& ds, size_t uuidSize);
 };


### PR DESCRIPTION
Fix https://github.com/stoprocent/noble/issues/39
For some reason on Windows 11 when trying to discover service, a disconnect event will be emitted from some staled BluetoothLEDevice instance. Identifying the device just by uuid is not enough. Have to ensure peripheral.device is referencing the same device or otherwise it will be false firing.
Also added closing service, session and device on disconnect to ensure proper disconnection from windows.
(The lack of this cleanup might be the reason of the staled device instance exist in the first place)