### PR TITLE
fix: waitForPoweredOnAsync does not timeout shortly after noble initialized

### DIFF
--- a/lib/noble.js
+++ b/lib/noble.js
@@ -171,8 +171,8 @@ class Noble extends EventEmitter {
       }, timeout);
 
       const listener = (state) => {
-        clearTimeout(timeoutId);
         if (state === 'poweredOn') {
+          clearTimeout(timeoutId);
           resolve();
         } else {
           this.once('stateChange', listener);


### PR DESCRIPTION
With bluetooth turned off, if you call waitForPoweredOnAsync right after initializing noble, the first "stateChange" received will be "poweredOff" but still cause clearTimeout, hence it will never timeout. Should clearTimeout only when poweredOn