### PR TITLE
fix(noble): disconnect event type and error handling

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -122,14 +122,14 @@ declare module '@stoprocent/noble' {
         toString(): string;
     
         on(event: "connect", listener: (error: Error | undefined) => void): this;
-        on(event: "disconnect", listener: (error: Error | undefined) => void): this;
+        on(event: "disconnect", listener: (reason: string) => void): this;
         on(event: "rssiUpdate", listener: (rssi: number) => void): this;
         on(event: "servicesDiscover", listener: (services: Service[]) => void): this;
         on(event: "mtu", listener: (mtu: number) => void): this;
         on(event: string, listener: Function): this;
     
         once(event: "connect", listener: (error: Error | undefined) => void): this;
-        once(event: "disconnect", listener: (error: Error | undefined) => void): this;
+        once(event: "disconnect", listener: (reason: string) => void): this;
         once(event: "rssiUpdate", listener: (rssi: number) => void): this;
         once(event: "servicesDiscover", listener: (services: Service[]) => void): this;
         once(event: string, listener: Function): this;

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -431,7 +431,7 @@ class Noble extends EventEmitter {
     this._bindings.disconnect(peripheralId);
   }
 
-  _onDisconnect (peripheralId, reason) {
+  _onDisconnect (peripheralId, reason = 'unknown') {
     const peripheral = this._peripherals.get(peripheralId);
 
     if (peripheral) {
@@ -786,7 +786,7 @@ class Noble extends EventEmitter {
 
   async _withDisconnectHandler (peripheralId, operation) {
     return new Promise((resolve, reject) => {
-      const disconnectListener = error => reject(error);
+      const disconnectListener = reason => reject(new Error(`Disconnected ${reason}`));
       this.once(`disconnect:${peripheralId}`, disconnectListener);
       
       Promise.resolve(operation())

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -932,4 +932,18 @@ describe('noble', () => {
       expect(peripheral.state).toBe('disconnected');
     });
   });
+
+  describe("_withDisconnectHandler", () => {
+    test("resolves operation result", async () => {
+      const promise = noble._withDisconnectHandler('peripheralUuid', () => Promise.resolve(1))
+      await expect(promise).resolves.toBe(1)
+    })
+
+    test("throws disconnect error if disconnected before resolve", async () => {
+      noble._peripherals.set('uuid', {emit: jest.fn()});
+      const promise = noble._withDisconnectHandler('uuid', () => Promise.resolve(1))
+      noble._onDisconnect('uuid')
+      await expect(promise).rejects.toThrow('Disconnected unknown')
+    })
+  })
 });


### PR DESCRIPTION
- disconnect event emits a reason string (or undefined), not an error
- Mac & Win bindings don't emit a reason, so default to "unknown"
- reject an actual error on disconnect, not a string/undefined