### PR TITLE
Fix “unknown peripheral null connected!” warning

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -130,6 +130,7 @@ NobleBindings.prototype.connect = function (peripheralUuid, parameters = {}) {
   const processNextConnection = () => {
     if (this._connectionQueue.length === 1) {
       const nextConn = this._connectionQueue[0]; // Look at next connection but don't remove yet
+      this._pendingConnectionUuid = nextConn.id;
       this._hci.createLeConn(nextConn.address, nextConn.addressType, nextConn.params, Object.keys(this._handles).length === 0);
     }
   };
@@ -389,7 +390,8 @@ NobleBindings.prototype.onLeConnComplete = function (
     this._gatts[handle].exchangeMtu();
   } else {
     const currentConn = this._connectionQueue[0];
-    uuid = currentConn ? currentConn.id : null;
+    const addrUuid = address ? this.addressToId(address) : null;
+    uuid = addrUuid || (currentConn ? currentConn.id : (this._pendingConnectionUuid || null));
     let statusMessage = Hci.STATUS_MAPPER[status] || 'HCI Error: Unknown';
     const errorCode = ` (0x${status.toString(16)})`;
     statusMessage = statusMessage + errorCode;
@@ -398,6 +400,7 @@ NobleBindings.prototype.onLeConnComplete = function (
 
   // Remove the completed/failed connection attempt from queue
   this._connectionQueue.shift();
+  this._pendingConnectionUuid = null;
 
   this.emit('connect', uuid, error);
 


### PR DESCRIPTION
This fixes a race condition when cancelConnect() is called immediately, and the connection queue can be emptied before the controller completes with an error. Previously, this caused uuid to be null in the connect event, triggering the "unknown peripheral null connected!" warning.

This code can reproduce the warning:

```
const noble = require('@stoprocent/noble');

const MAC = '112233445566';

async function main() {
  await noble.waitForPoweredOnAsync();
  setTimeout(() => noble.cancelConnect(MAC), 10);
  await noble.connectAsync(MAC).catch(() => {});
}

main();
```