### PR TITLE
fix(windows): don't emit short local name when complete available

### DIFF
--- a/lib/win/src/peripheral_winrt.h
+++ b/lib/win/src/peripheral_winrt.h
@@ -73,6 +73,7 @@ public:
     std::optional<GattSession> gattSession;
     winrt::event_token maxPduSizeChangedToken;
     std::unordered_map<winrt::guid, CachedService> cachedServices;
+    bool nameIsComplete { false }; // `name` is the Complete Local Name
 
 private:
     void GetServiceFromDevice(winrt::guid serviceUuid,


### PR DESCRIPTION
I'm using `noble` with a device that sends a Shortened Local Name in its advertisement packet and a Complete Local Name in its scan response, and I was finding that the `'discover'` events would alternate between the shortened and complete local name. This is because Windows doesn't distinguish between the name types when generating `advertisment.LocalName()`.

This PR switches to parsing the local name advertisement data sections directly, and adds a flag to indicate whether a Complete Local Name has been received.