### PR TITLE
fix(hci/gap): bound extended adv EIR to Data_Length and harden malformed service-data parsing

### DIFF
--- a/lib/hci-socket/gap.js
+++ b/lib/hci-socket/gap.js
@@ -375,16 +375,25 @@ Gap.prototype.parseServices = function (
           } else {
             uuidLength = 16;
           }
-          
+
+          if (bytes.length < uuidLength) {
+            debug(
+              `invalid EIR service data, type = 0x${eirType.toString(16)}, expected uuid bytes = ${uuidLength}, actual = ${bytes.length}`
+            );
+            break;
+          }
+
           const serviceUuid = bytes
             .slice(0, uuidLength)
             .toString('hex')
             .match(/.{1,2}/g)
             .reverse()
             .join('');
-          
+
           // Find existing service data index
-          const existingIndex = advertisement.serviceData.findIndex(s => s.uuid === serviceUuid);
+          const existingIndex = advertisement.serviceData.findIndex(
+            s => s.uuid === serviceUuid
+          );
           const serviceData = {
             uuid: serviceUuid,
             data: bytes.slice(uuidLength, bytes.length)

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -1233,17 +1233,25 @@ Hci.prototype.processLeAdvertisingReport = function (numReports, data) {
 };
 
 Hci.prototype.processLeExtendedAdvertisingReport = function (numReports, data) {
-  try {
-    for (let i = 0; i < numReports; i++) {
+  for (let i = 0; i < numReports; i++) {
+    let type;
+    let address;
+    let addressType;
+    let txpower;
+    let rssi;
+    let eir;
+    let eirLength;
+
+    try {
       if (data.length < 24) {
         console.warn(
           `processLeExtendedAdvertisingReport: Caught illegal packet (too short: ${data.length} < 24)`
         );
         break;
       }
-      const type = data.readUInt16LE(0);
-      const addressType = data.readUInt8(2) === 0x01 ? 'random' : 'public';
-      const address = data
+      type = data.readUInt16LE(0);
+      addressType = data.readUInt8(2) === 0x01 ? 'random' : 'public';
+      address = data
         .slice(3, 9)
         .toString('hex')
         .match(/.{1,2}/g)
@@ -1252,8 +1260,8 @@ Hci.prototype.processLeExtendedAdvertisingReport = function (numReports, data) {
       const primaryPHY = data.readUInt8(9);
       const secondaryPHY = data.readUInt8(10);
       const sid = data.readUInt8(11);
-      const txpower = data.readUInt8(12);
-      const rssi = data.readInt8(13);
+      txpower = data.readUInt8(12);
+      rssi = data.readInt8(13);
       const periodicAdvInterval = data.readUInt16LE(14);
       const directAddressType =
         data.readUInt8(16) === 0x01 ? 'random' : 'public';
@@ -1263,14 +1271,14 @@ Hci.prototype.processLeExtendedAdvertisingReport = function (numReports, data) {
         .match(/.{1,2}/g)
         .reverse()
         .join(':');
-      const eirLength = data.readUInt8(23);
+      eirLength = data.readUInt8(23);
       if (data.length < 24 + eirLength) {
         console.warn(
           `processLeExtendedAdvertisingReport: Caught illegal packet (eir length ${eirLength} exceeds remaining ${data.length - 24})`
         );
         break;
       }
-      const eir = data.slice(24);
+      eir = data.slice(24, 24 + eirLength);
 
       debug(`\t\t\ttype = ${type}`);
       debug(`\t\t\taddress = ${address}`);
@@ -1287,24 +1295,25 @@ Hci.prototype.processLeExtendedAdvertisingReport = function (numReports, data) {
       debug(`\t\t\tdirect address = ${directAddress}`);
       debug(`\t\t\teir length = ${eirLength}`);
       debug(`\t\t\teir = ${eir.toString('hex')}`);
-
-      this.emit(
-        'leExtendedAdvertisingReport',
-        0,
-        type,
-        address,
-        addressType,
-        txpower,
-        rssi,
-        eir
+    } catch (e) {
+      console.warn(
+        `processLeExtendedAdvertisingReport: Caught illegal packet (buffer overflow): ${e}`
       );
-
-      data = data.slice(eirLength + 24);
+      break;
     }
-  } catch (e) {
-    console.warn(
-      `processLeExtendedAdvertisingReport: Caught illegal packet (buffer overflow): ${e}`
+
+    this.emit(
+      'leExtendedAdvertisingReport',
+      0,
+      type,
+      address,
+      addressType,
+      txpower,
+      rssi,
+      eir
     );
+
+    data = data.slice(eirLength + 24);
   }
 };
 


### PR DESCRIPTION
## Summary

Follow-up to https://github.com/stoprocent/noble/pull/64

This fixes an extended advertising parsing issue where the current report's EIR payload was not bounded to its declared `Data_Length`. When multiple extended advertising reports are included in a single HCI event, bytes from the next report could be passed into `gap.js` as if they belonged to the current report.

It also hardens `gap.js` service-data parsing so malformed/truncated service-data AD fields do not crash parsing.

## What changed

### `lib/hci-socket/hci.js`
- Bound the extended advertising EIR slice to `eirLength`
  - from `data.slice(24)`
  - to `data.slice(24, 24 + eirLength)`
- Kept malformed packet guards for:
  - short report headers (`data.length < 24`)
  - truncated EIR payloads (`data.length < 24 + eirLength`)
- Moved `this.emit('leExtendedAdvertisingReport', ...)` outside the parser `try/catch`
  - parser errors remain labeled as malformed packet issues
  - downstream listener errors are no longer misattributed as HCI parser overflows

### `lib/hci-socket/gap.js`
- Added a guard for service-data AD types (`0x16`, `0x20`, `0x21`) so UUID parsing only runs when the payload is at least the required UUID length
- Malformed/truncated service-data entries are skipped instead of throwing

## Why this is safe

- Extended advertising reports already carry `Data_Length`; bounding the EIR slice to that length matches the report framing
- For service-data AD fields, the UUID is mandatory, so a payload shorter than the UUID length is malformed
- Valid `UUID-only` service-data fields (empty service payload) still work

## Validation

- Local test suite passes
- Long-running scan churn reproduction on Linux no longer reproduced the `null.reverse()` failure after applying the fix