### PR TITLE
Add ability to set custom MTU via connect options

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -336,7 +336,8 @@ NobleBindings.prototype.onLeConnComplete = function (
       addressType,
       address
     );
-    const gatt = new Gatt(address, aclStream);
+    const connectionParams = this._connectionQueue.length > 0 ? this._connectionQueue[0].params : {};
+    const gatt = new Gatt(address, aclStream, connectionParams && connectionParams.mtu);
     const signaling = new Signaling(handle, aclStream);
 
     this._gatts[uuid] = this._gatts[handle] = gatt;

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -56,7 +56,7 @@ const GATT_SERVER_CHARAC_CFG_UUID = 0x2903;
 const ATT_CID = 0x0004;
 /* eslint-enable no-unused-vars */
 
-const Gatt = function (address, aclStream) {
+const Gatt = function (address, aclStream, desiredMtu) {
   this._address = address;
   this._aclStream = aclStream;
 
@@ -68,7 +68,7 @@ const Gatt = function (address, aclStream) {
   this._commandQueue = [];
 
   this._mtu = 23;
-  this._desired_mtu = 256;
+  this._desired_mtu = desiredMtu || 256;
   this._security = 'low';
 
   this.onAclStreamDataBinded = this.onAclStreamData.bind(this);


### PR DESCRIPTION
## Summary

- Allows users to specify a desired MTU per-connection via `peripheral.connect({ mtu: 512 })`, resolving the hardcoded 256-byte limit
- Defaults to 256 when not specified, preserving existing behavior
- Only affects the HCI socket binding (Mac/Win handle MTU at the OS level)

## Usage

```js
// Before (hardcoded to 256)
await peripheral.connectAsync();

// After (custom MTU)
await peripheral.connectAsync({ mtu: 512 });
```

## Changes

- **`lib/hci-socket/gatt.js`**: Accept optional `desiredMtu` parameter in `Gatt` constructor, used as `_desired_mtu` (falls back to 256)
- **`lib/hci-socket/bindings.js`**: Extract `mtu` from connection parameters and pass it to the `Gatt` constructor

## Test plan

- [ ] Connect to a peripheral without `mtu` option — should negotiate MTU of 256 (unchanged behavior)
- [ ] Connect with `{ mtu: 512 }` — should negotiate up to 512 with the remote device
- [ ] Verify `peripheral.mtu` reflects the negotiated value after connection

Closes #71

https://claude.ai/code/session_014RCJBatLRdZ3pqdSFaAgkv