### PR TITLE
Fix disconnect on Windows

### DIFF
--- a/examples/peripheral-explorer-async.js
+++ b/examples/peripheral-explorer-async.js
@@ -79,6 +79,8 @@ noble.on('discover', async (peripheral) => {
     console.log();
 
     await explore(peripheral);
+  } else {
+    console.log(`Peripheral with ID ${peripheral.id} and name ${peripheral.advertisement?.localName} ignored`);
   }
 });
 

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -290,7 +290,7 @@ bool BLEManager::Connect(const std::string& uuid)
             
             // Add to device map
             mDeviceMap.emplace(std::make_pair(uuid, std::move(peripheral)));
-        } catch (const std::exception& e) {
+        } catch (const std::exception&) {
             mEmit.Connected(uuid, "invalid device address format");
             return false;
         }

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -413,7 +413,7 @@ void BLEManager::OnConnectionStatusChanged(BluetoothLEDevice device,
             return;
         }
         PeripheralWinrt& peripheral = mDeviceMap[uuid];
-        if(peripheral.device.has_value() && &(peripheral.device.value()) == &device )
+        if (peripheral.device.has_value() && peripheral.device.value() == device)
         {
             peripheral.Disconnect();
             mNotifyMap.Remove(uuid);

--- a/lib/win/src/noble_winrt.cc
+++ b/lib/win/src/noble_winrt.cc
@@ -277,7 +277,7 @@ Napi::Value NobleWinrt::AddressToId(const Napi::CallbackInfo& info)
         }
         
         return Napi::String::New(info.Env(), cleanUuid.c_str());
-    } catch (const std::exception& e) {
+    } catch (const std::exception&) {
         return info.Env().Null();
     }
 }


### PR DESCRIPTION
- Fixes #77 
- Fixes win build warnings
- Modifies example script to log ignored ids, useful in case you don't know the id

