### PR TITLE
chore: declare dbus-next as optional peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,14 @@
   "optionalDependencies": {
     "@stoprocent/bluetooth-hci-socket": "^2.2.6"
   },
+  "peerDependencies": {
+    "dbus-next": "^0.10.0"
+  },
+  "peerDependenciesMeta": {
+    "dbus-next": {
+      "optional": true
+    }
+  },
   "devDependencies": {
     "@babel/eslint-parser": "^7.27.0",
     "@commitlint/cli": "^19.3.0",


### PR DESCRIPTION
## Summary
- Adds `dbus-next: ^0.10.0` under `peerDependencies` with `peerDependenciesMeta.optional: true`
- Replaces the undocumented, prose-only requirement (in README + lazy `require` error message) with a machine-readable version range
- No runtime behavior change — the binding still lazily `require`s `dbus-next` and falls back to a friendly install error if missing

## Why
`@stoprocent/bluetooth-hci-socket` is in `optionalDependencies` because it's a native build that breaks installs on macOS/Windows. `dbus-next` is pure JS but Linux-only by purpose — making it a hard or optional dependency would pull a Linux-only library onto every Mac/Win install. The peer-optional pattern is the standard idiom for plug-in backends (eslint plugins, vite plugins, jest reporters, etc.) and gives us:
- Renovate/Dependabot/`npm ls` visibility into the supported version range
- No phantom install on platforms that don't use the D-Bus backend (npm 7+ does not auto-install optional peers)
- Same UX as today for missing-peer: the existing `try/catch` around `require('dbus-next')` still surfaces the install hint

The intent already leaked into `lib/dbus/bindings.js:37` (`"dbus-next is an optional peer of this Linux-only backend"`); this just makes the manifest reflect that.

## Test plan
- [x] `npm test` — 17 suites, 654 tests pass
- [x] `npm run lint` — clean
- [x] `npm install --dry-run` — manifest validates
- [ ] CI green on Linux/macOS/Windows
- [ ] Verify `npm ls dbus-next` warns appropriately when the D-Bus backend is selected without `dbus-next` installed (manual, Linux)

🤖 Generated with [Claude Code](https://claude.com/claude-code)