### PR TITLE
Tell Windows to actively maintain the BLE connection.

### DIFF
--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -362,6 +362,8 @@ void BLEManager::OnGattSessionCreated(IAsyncOperation<GattSession> asyncOp, Asyn
             peripheral.gattSession = session;
             auto token = session.MaxPduSizeChanged(onPduSizeChanged);
             peripheral.maxPduSizeChangedToken = token;
+
+            session.MaintainConnection(true);
         }
         else
         {


### PR DESCRIPTION
set GattSession.MaintainConnection to true for reliable MTU negotiation

On Windows, BluetoothLEDevice::FromBluetoothAddressAsync returns before the physical BLE connection is established. 
Without MaintainConnection,the first GATT operation (GetGattServicesAsync) triggers the connection,
but by then the MTU is still at the default 23. 
If the peripheral negotiates a larger MTU during service discovery,
the race condition can exhaust the peripheral's ATT buffer pool.

Setting MaintainConnection(true) ensures Windows proactively maintains the GATT session, 
allowing the peripheral's MTU exchange request to be processed before service discovery begins.