### PR TITLE
fix(dbus): re-surface cached BlueZ devices at scan start

### DIFF
--- a/lib/dbus/bindings.js
+++ b/lib/dbus/bindings.js
@@ -308,6 +308,28 @@ class DbusBindings extends EventEmitter {
       await this._adapterIface.StartDiscovery();
       this._isScanning = true;
     }
+
+    // Re-read BlueZ's object tree and surface cached devices.
+    // BlueZ won't emit InterfacesAdded for devices already in its cache,
+    // so without this refresh a new scan would miss them entirely.
+    try {
+      const managed = await this._objectManager.GetManagedObjects();
+      for (const [path, ifaces] of Object.entries(managed)) {
+        const unwrapped = {};
+        for (const [iface, props] of Object.entries(ifaces)) {
+          unwrapped[iface] = unwrapDict(props);
+        }
+        this._objects.set(path, Object.assign(this._objects.get(path) || {}, unwrapped));
+        if (unwrapped[DEVICE_IFACE] && this._isUnderAdapter(path)) {
+          const address = unwrapped[DEVICE_IFACE].Address || devicePathToAddress(path);
+          if (address && this._devices.has(addressToId(address))) continue;
+          this._handleDeviceProps(path, unwrapped[DEVICE_IFACE]);
+        }
+      }
+    } catch (err) {
+      debug('startScanning: cache refresh failed: %s', err.message);
+    }
+
     this.emit('scanStart', !!allowDuplicates);
   }
 


### PR DESCRIPTION
Matter device commissioning via matterjs-server consistently failed for the IKEA sensors (e.g. TIMMERFLOTTE) because noble never fired a `discover` event for it. bluetoothd had already cached the device from background scanning, so BlueZ never emitted an InterfacesAdded signal when noble started its own scan. The device was invisible to noble.

After StartDiscovery, re-read GetManagedObjects and replay _handleDeviceProps for every cached device under the adapter so they appear as discover events.


I'm not really a Javascript developer. So this works for me, not sure everything is 100% correct. I can remove the debug but I needed it to understand why devices vanished after they where detected first.

Feel free to modify the commit and push to the repo to update it. I'm currently moving to a new location so I'm mostly unavailable till next week.