### PR TITLE
fix(win): don't report adapter unsupported on Windows 10 < 2004

### DIFF
--- a/lib/win/src/radio_watcher.cc
+++ b/lib/win/src/radio_watcher.cc
@@ -69,15 +69,29 @@ winrt::fire_and_forget RadioWatcher::OnRadioChanged() {
         if (adapter) {
             auto radio = co_await adapter.GetRadioAsync();
 
-            AdapterCapabilities capabilities;
+            AdapterCapabilities capabilities = {};
             capabilities.bluetoothAddress = adapter.BluetoothAddress();
             capabilities.classicSecureConnectionsSupported = adapter.AreClassicSecureConnectionsSupported();
             capabilities.lowEnergySecureConnectionsSupported = adapter.AreLowEnergySecureConnectionsSupported();
-            capabilities.extendedAdvertisingSupported = adapter.IsExtendedAdvertisingSupported();
             capabilities.lowEnergySupported = adapter.IsLowEnergySupported();
-            capabilities.maxAdvertisementDataLength = adapter.MaxAdvertisementDataLength();
             capabilities.peripheralRoleSupported = adapter.IsPeripheralRoleSupported();
             capabilities.centralRoleSupported = adapter.IsCentralRoleSupported();
+
+            // IsExtendedAdvertisingSupported and MaxAdvertisementDataLength were
+            // introduced in Windows 10, version 2004 (build 19041). On older builds
+            // (e.g. 1909 / 18363) these accessors throw, which would otherwise abort
+            // the whole capability read and make a working adapter look "unsupported".
+            // Guard them separately so they simply fall back to conservative defaults.
+            try
+            {
+                capabilities.extendedAdvertisingSupported = adapter.IsExtendedAdvertisingSupported();
+                capabilities.maxAdvertisementDataLength = adapter.MaxAdvertisementDataLength();
+            }
+            catch (const winrt::hresult_error&)
+            {
+                capabilities.extendedAdvertisingSupported = false;
+                capabilities.maxAdvertisementDataLength = 0;
+            }
 
             Radio bluetooth = nullptr;
             if(adapter.IsCentralRoleSupported())


### PR DESCRIPTION
## Problem

On Windows 10 builds older than **2004 (19041)** — reported on **1909 / 18363** — noble always emits `stateChange = unsupported`, even with a fully working BLE adapter.

`RadioWatcher::OnRadioChanged()` reads every `BluetoothAdapter` capability inside a single `try` block. Two of those properties only exist since Windows 10 2004:

- `BluetoothAdapter.IsExtendedAdvertisingSupported`
- `BluetoothAdapter.MaxAdvertisementDataLength`

On older builds the accessors throw `winrt::hresult_error`, the single throw jumps to the `catch`, and the callback fires with a **null radio + empty capabilities**. Downstream, `BLEManager::OnRadio()` maps a null radio to `AdapterState::Unsupported` → `unsupported` is emitted. All other capabilities read here have been available since 1709, so they aren't the problem.

## Fix

Read the two 2004+ properties in their own guarded block so an unavailable property falls back to conservative defaults (`false` / `0`) instead of aborting the entire capability read. Behaviour on Windows 10 2004+ / Windows 11 is unchanged; older builds now correctly report `poweredOn`.

```cpp
try {
    capabilities.extendedAdvertisingSupported = adapter.IsExtendedAdvertisingSupported();
    capabilities.maxAdvertisementDataLength = adapter.MaxAdvertisementDataLength();
} catch (const winrt::hresult_error&) {
    capabilities.extendedAdvertisingSupported = false;
    capabilities.maxAdvertisementDataLength = 0;
}
```

I kept this intentionally minimal — a per-property `try` fallback rather than introducing `ApiInformation` plumbing — to avoid adding machinery for a two-property edge case. Happy to switch to an `ApiInformation::IsPropertyPresent` gate instead if you'd prefer the explicit version-check approach.

Note: this touches the same function as the #85 crash fix, so the two PRs will need a trivial conflict resolution depending on merge order.

Fixes #84

https://claude.ai/code/session_013BTp5XgwGPsnpgo8V1vdn7

---
_Generated by [Claude Code](https://claude.ai/code/session_013BTp5XgwGPsnpgo8V1vdn7)_