### PR TITLE
fix(win): prevent crash when bthserv is disabled

### DIFF
--- a/lib/win/src/radio_watcher.cc
+++ b/lib/win/src/radio_watcher.cc
@@ -80,7 +80,11 @@ winrt::fire_and_forget RadioWatcher::OnRadioChanged() {
             capabilities.centralRoleSupported = adapter.IsCentralRoleSupported();
 
             Radio bluetooth = nullptr;
-            if(adapter.IsCentralRoleSupported())
+            // GetRadioAsync() can resolve to a null radio when the Bluetooth
+            // Support Service (bthserv) is disabled, even though the adapter is
+            // still enumerated. Guard against it so we don't call StateChanged()
+            // on a null radio, which would otherwise crash the process.
+            if (adapter.IsCentralRoleSupported() && radio)
             {
                 // Always set up radio state monitoring for any radio (on or off)
                 bluetooth = radio;
@@ -108,7 +112,11 @@ winrt::fire_and_forget RadioWatcher::OnRadioChanged() {
             AdapterCapabilities emptyCapabilities = {};
             radioStateChanged(mRadio, emptyCapabilities);
         }
-    } catch (const winrt::hresult_error&) {
+    } catch (...) {
+        // OnRadioChanged() runs as a fire_and_forget coroutine: any exception
+        // that escapes here terminates the whole process. Catch everything (not
+        // just winrt::hresult_error) and degrade gracefully to an empty adapter
+        // so a disabled bthserv / unexpected WinRT failure can't take down the app.
         mRadio = nullptr;
         mRadioStateChangedRevoker.revoke();
         AdapterCapabilities emptyCapabilities = {};


### PR DESCRIPTION
## Problem

If the Windows **Bluetooth Support Service (`bthserv`)** is disabled, the entire process crashes instead of degrading to `unsupported` / `poweredOff`.

In `RadioWatcher::OnRadioChanged()` the adapter can still be enumerated while `adapter.GetRadioAsync()` resolves to a **null radio**. The central-role branch then unconditionally does:

```cpp
bluetooth = radio;                       // null
mRadioStateChangedRevoker = radio.StateChanged(...);   // call on null radio -> crash
```

On top of that, `OnRadioChanged()` is a `fire_and_forget` coroutine, so any exception that escapes the single `catch (const winrt::hresult_error&)` (a different exception type, or a failure after a `co_await` resumes off-frame) terminates the whole process rather than being handled.

## Fix

Two small, defensive changes:

1. **Null-guard the radio** before wiring up `StateChanged()` — `if (adapter.IsCentralRoleSupported() && radio)`. With a null radio we fall through to the existing empty-adapter path instead of dereferencing it.
2. **Broaden the coroutine catch to `catch (...)`** so any WinRT failure degrades to an empty adapter instead of crashing. This mirrors the existing `catch (...)` handling already used in `notify_map.cc` and `winrt_cpp.cc`.

## Note

The original report (#85) is a one-liner with no version/stack trace. This is the credible crash path given the code, and the hardening is worth doing regardless, but it would still be good to confirm noble version + OS build + the actual error with the reporter.

This touches the same function as #86 (the older-Windows-10 capability fix), so the two PRs will need a trivial conflict resolution depending on merge order.

Fixes #85

https://claude.ai/code/session_013BTp5XgwGPsnpgo8V1vdn7

---
_Generated by [Claude Code](https://claude.ai/code/session_013BTp5XgwGPsnpgo8V1vdn7)_