### PR TITLE
fix(win): maintain the GATT session to stabilize MTU negotiation

### DIFF
--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -362,6 +362,16 @@ void BLEManager::OnGattSessionCreated(IAsyncOperation<GattSession> asyncOp, Asyn
             peripheral.gattSession = session;
             auto token = session.MaxPduSizeChanged(onPduSizeChanged);
             peripheral.maxPduSizeChangedToken = token;
+
+            // Proactively maintain the GATT session so Windows establishes the
+            // physical connection up front. FromBluetoothAddressAsync returns
+            // before the link is up; without this the first GATT operation
+            // triggers the connection while the MTU is still the default 23,
+            // racing the peripheral's MTU exchange during service discovery.
+            // MaintainConnection defaults to false; the session is released in
+            // PeripheralWinrt::Disconnect(), so this does not keep the link open
+            // after an intentional disconnect.
+            session.MaintainConnection(true);
         }
         else
         {


### PR DESCRIPTION
## Summary

Sets `GattSession.MaintainConnection(true)` right after the session is created in `OnGattSessionCreated`, so Windows establishes the physical BLE connection up front instead of lazily on the first GATT operation.

On Windows, `BluetoothLEDevice::FromBluetoothAddressAsync` returns before the link is established. Without `MaintainConnection`, the first GATT operation (`GetGattServicesAsync`) triggers the connection — but by then the MTU is still the default 23. If the peripheral negotiates a larger MTU during service discovery, the race can exhaust the peripheral's ATT buffer pool.

`MaintainConnection` defaults to `false`, and the session is released in `PeripheralWinrt::Disconnect()` (`gattSession->Close()`), so this does **not** keep the link open after an intentional disconnect.

### Verified against Microsoft's documentation
- [`GattSession.MaintainConnection`](https://learn.microsoft.com/en-us/uwp/api/windows.devices.bluetooth.genericattributeprofile.gattsession.maintainconnection) — read/write `Boolean`, default `false`; when `true` "the system waits indefinitely for a connection, and it will connect when the device is available."
- [Bluetooth GATT Client guide](https://learn.microsoft.com/en-us/windows/uwp/devices-sensors/gatt-client) — "To initiate a connection, you must set `GattSession.MaintainConnection` to true, or call an uncached service discovery method … or perform a read/write operation." This confirms the lazy-connect behavior the change addresses.

## Why this PR exists

This is the **same change as #82 by @ranbochen** — full credit to them (preserved as co-author on the commit). That PR is a first-time-contributor fork PR, and for some reason its CI never ran: the workflow runs queued at open time were gated for approval and have since aged out, leaving 0 checks and no way to re-trigger them from that PR. Re-applying the change on a branch in this repository lets the build/test/lint workflows run normally and go through the standard review gates.

Supersedes #82.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013BTp5XgwGPsnpgo8V1vdn7

---
_Generated by [Claude Code](https://claude.ai/code/session_013BTp5XgwGPsnpgo8V1vdn7)_