### PR TITLE
fix(dbus): match other backends for scan filtering and connect failures

### DIFF
--- a/lib/dbus/bindings.js
+++ b/lib/dbus/bindings.js
@@ -3,7 +3,6 @@ const debug = require('debug')('noble-dbus');
 
 const {
   normalizeUuid,
-  expandUuid,
   addressToId,
   devicePathToAddress,
   deviceIdFromPath,
@@ -163,6 +162,9 @@ class DbusBindings extends EventEmitter {
     // Per-characteristic notify listener: path -> { iface, listener }
     this._charPropsListeners = new Map();
 
+    // Per-device advertisement watcher during scan: path -> { props, listener }
+    this._scanPropsListeners = new Map();
+
     this._onInterfacesAddedBound = this._onInterfacesAdded.bind(this);
     this._onInterfacesRemovedBound = this._onInterfacesRemoved.bind(this);
     this._onAdapterPropsBound = this._onAdapterProperties.bind(this);
@@ -263,7 +265,10 @@ class DbusBindings extends EventEmitter {
       entry.props.off('PropertiesChanged', entry.listener);
     }
     this._charPropsListeners.clear();
-    if (this._isScanning && this._adapterIface) {
+    const wasScanning = this._isScanning;
+    this._isScanning = false;
+    this._unwatchAllDeviceProps();
+    if (wasScanning && this._adapterIface) {
       this._adapterIface.StopDiscovery().catch(() => {});
     }
     if (this._bus && typeof this._bus.disconnect === 'function') {
@@ -292,13 +297,12 @@ class DbusBindings extends EventEmitter {
       throw new Error('adapter not initialized');
     }
     const { Variant } = this._dbus;
+    // No UUIDs filter: BlueZ matches it against advertised UUIDs only (AD
+    // 0x02/0x03), hiding service-data-only devices. Filtered in software instead.
     const filter = {
       Transport: new Variant('s', 'le'),
       DuplicateData: new Variant('b', !!allowDuplicates)
     };
-    if (this._scanServiceUuids.length > 0) {
-      filter.UUIDs = new Variant('as', this._scanServiceUuids.map(expandUuid));
-    }
     try {
       await this._adapterIface.SetDiscoveryFilter(filter);
     } catch (err) {
@@ -319,11 +323,11 @@ class DbusBindings extends EventEmitter {
         for (const [iface, props] of Object.entries(ifaces)) {
           unwrapped[iface] = unwrapDict(props);
         }
-        this._objects.set(path, Object.assign(this._objects.get(path) || {}, unwrapped));
+        const merged = Object.assign(this._objects.get(path) || {}, unwrapped);
+        this._objects.set(path, merged);
         if (unwrapped[DEVICE_IFACE] && this._isUnderAdapter(path)) {
-          const address = unwrapped[DEVICE_IFACE].Address || devicePathToAddress(path);
-          if (address && this._devices.has(addressToId(address))) continue;
-          this._handleDeviceProps(path, unwrapped[DEVICE_IFACE]);
+          this._handleDeviceProps(path, merged[DEVICE_IFACE]);
+          this._watchDeviceProps(path);
         }
       }
     } catch (err) {
@@ -341,13 +345,18 @@ class DbusBindings extends EventEmitter {
   }
 
   async _stopScanning () {
-    if (this._isScanning && this._adapterIface) {
+    const wasScanning = this._isScanning;
+    // Clear _isScanning before releasing watchers so a _watchDeviceProps still
+    // suspended on getProxyObject fails its post-await guard instead of
+    // re-attaching a listener that would outlive the scan.
+    this._isScanning = false;
+    this._unwatchAllDeviceProps();
+    if (wasScanning && this._adapterIface) {
       try {
         await this._adapterIface.StopDiscovery();
       } catch (err) {
         debug('StopDiscovery failed: %s', err.message);
       }
-      this._isScanning = false;
     }
     this.emit('scanStop');
   }
@@ -363,7 +372,8 @@ class DbusBindings extends EventEmitter {
     this._objects.set(path, Object.assign(existing, unwrapped));
 
     if (unwrapped[DEVICE_IFACE] && this._isUnderAdapter(path)) {
-      this._handleDeviceProps(path, unwrapped[DEVICE_IFACE]);
+      this._handleDeviceProps(path, existing[DEVICE_IFACE]);
+      if (this._isScanning) this._watchDeviceProps(path);
     }
     // Trigger services-resolved processing if a device just gained ServicesResolved
     if (unwrapped[GATT_SERVICE_IFACE] || unwrapped[GATT_CHAR_IFACE] || unwrapped[GATT_DESC_IFACE]) {
@@ -380,6 +390,7 @@ class DbusBindings extends EventEmitter {
       }
     }
     if (ifaces.includes(DEVICE_IFACE)) {
+      this._unwatchDeviceProps(path);
       const id = deviceIdFromPath(path);
       if (id && this._devices.has(id)) {
         this._onDeviceDisconnected(id, 'removed');
@@ -427,8 +438,10 @@ class DbusBindings extends EventEmitter {
       device.address = address;
       if (props.AddressType) device.addressType = props.AddressType;
       if (typeof props.RSSI === 'number') device.rssi = props.RSSI;
-      Object.assign(device.advertisement, buildAdvertisement(props));
+      device.advertisement = buildAdvertisement(props);
     }
+
+    if (!this._matchesScanFilter(device.advertisement)) return;
 
     this.emit(
       'discover',
@@ -440,6 +453,52 @@ class DbusBindings extends EventEmitter {
       device.rssi,
       device.scannable
     );
+  }
+
+  _matchesScanFilter (advertisement) {
+    if (this._scanServiceUuids.length === 0) return true;
+    const advertised = advertisement.serviceUuids || [];
+    const fromData = (advertisement.serviceData || []).map(sd => sd.uuid);
+    return advertised.concat(fromData).some(uuid => this._scanServiceUuids.includes(uuid));
+  }
+
+  // BlueZ often delivers ServiceData/UUIDs in a PropertiesChanged after the
+  // initial InterfacesAdded, so re-run discovery on every advertisement update
+  // — otherwise a device that only reveals a matching UUID later is missed.
+  async _watchDeviceProps (path) {
+    if (this._scanPropsListeners.has(path)) return;
+    let proxy;
+    try {
+      proxy = await this._bus.getProxyObject(BLUEZ_SERVICE, path);
+    } catch (err) {
+      debug('watchDeviceProps failed: %s', err.message);
+      return;
+    }
+    if (!this._isScanning || this._scanPropsListeners.has(path)) return;
+    const props = proxy.getInterface(PROPS_IFACE);
+    const listener = (iface, changed) => {
+      if (iface !== DEVICE_IFACE) return;
+      const stored = this._objects.get(path) || {};
+      stored[DEVICE_IFACE] = Object.assign(stored[DEVICE_IFACE] || {}, unwrapDict(changed));
+      this._objects.set(path, stored);
+      this._handleDeviceProps(path, stored[DEVICE_IFACE]);
+    };
+    props.on('PropertiesChanged', listener);
+    this._scanPropsListeners.set(path, { props, listener });
+  }
+
+  _unwatchDeviceProps (path) {
+    const entry = this._scanPropsListeners.get(path);
+    if (!entry) return;
+    entry.props.off('PropertiesChanged', entry.listener);
+    this._scanPropsListeners.delete(path);
+  }
+
+  _unwatchAllDeviceProps () {
+    for (const entry of this._scanPropsListeners.values()) {
+      entry.props.off('PropertiesChanged', entry.listener);
+    }
+    this._scanPropsListeners.clear();
   }
 
   // ---- Per-device proxy + property listening ----
@@ -483,9 +542,7 @@ class DbusBindings extends EventEmitter {
     return device;
   }
 
-  _onDeviceDisconnected (id, reason) {
-    const device = this._devices.get(id);
-    if (!device) return;
+  _teardownConnection (device, id) {
     if (device.proxy && device.propsListener) {
       const props = device.proxy.getInterface(PROPS_IFACE);
       props.off('PropertiesChanged', device.propsListener);
@@ -493,11 +550,24 @@ class DbusBindings extends EventEmitter {
     device.proxy = null;
     device.propsListener = null;
     device.servicesResolved = false;
-    if (device.connectPromise) {
-      device.connectPromise.reject(new Error(`disconnected: ${reason}`));
-      device.connectPromise = null;
-    }
     this._removeDeviceCharListeners(id);
+  }
+
+  _onDeviceDisconnected (id, reason) {
+    const device = this._devices.get(id);
+    if (!device) return;
+    // A drop while connecting is a connect failure, not a disconnect: reject so
+    // connect()'s catch tears down and emits 'connect'(err). Like hci-socket, a
+    // failed attempt emits no 'disconnect' (peripheral stays retryable).
+    if (device.connectPromise) {
+      const pending = device.connectPromise;
+      device.connectPromise = null;
+      pending.reject(new Error(`disconnected: ${reason}`));
+      return;
+    }
+    const wasConnected = !!device.proxy;
+    this._teardownConnection(device, id);
+    if (!wasConnected) return;
     this.emit('disconnect', id, reason);
   }
 
@@ -518,6 +588,11 @@ class DbusBindings extends EventEmitter {
   connect (peripheralUuid, _parameters) {
     peripheralUuid = normalizeId(peripheralUuid);
     this._connect(peripheralUuid).catch(err => {
+      // Release the half-open proxy/listener so a retry starts clean. No
+      // 'disconnect' — a failed attempt leaves the peripheral in 'error',
+      // matching the other backends.
+      const device = this._devices.get(peripheralUuid);
+      if (device) this._teardownConnection(device, peripheralUuid);
       this.emit('connect', peripheralUuid, err);
     });
   }

--- a/test/lib/dbus/bindings.test.js
+++ b/test/lib/dbus/bindings.test.js
@@ -518,4 +518,262 @@ describe('dbus/bindings', () => {
       expect(() => bindings.discoverServices(null, [])).not.toThrow();
     });
   });
+
+  describe('scan service-uuid filtering (software-side)', () => {
+    function emitDevice (deviceProps) {
+      const om = state.rootProxy.getInterface('org.freedesktop.DBus.ObjectManager');
+      om.emit('InterfacesAdded', '/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF', {
+        'org.bluez.Device1': wrapDict({ Address: 'AA:BB:CC:DD:EE:FF', AddressType: 'public', ...deviceProps })
+      });
+    }
+
+    test('does not push a UUIDs filter to BlueZ SetDiscoveryFilter', async () => {
+      const bindings = new DbusBindings();
+      bindings.start();
+      await flush();
+
+      bindings.startScanning(['180d'], false);
+      await flush();
+
+      const setFilter = state.ifaceCalls.find(c => c.method === 'SetDiscoveryFilter');
+      expect(setFilter).toBeDefined();
+      expect('UUIDs' in setFilter.args[0]).toBe(false);
+    });
+
+    test('discovers a device that advertises the UUID only in service data', async () => {
+      const bindings = new DbusBindings();
+      const discoveries = [];
+      bindings.on('discover', (...args) => discoveries.push(args));
+
+      bindings.start();
+      await flush();
+      bindings.startScanning(['180d'], false);
+      await flush();
+
+      emitDevice({
+        ServiceData: { '0000180d-0000-1000-8000-00805f9b34fb': v('ay', Buffer.from([0x01])) }
+      });
+      await flush();
+
+      expect(discoveries.length).toBe(1);
+      expect(discoveries[0][0]).toBe('aabbccddeeff');
+    });
+
+    test('filters out a device that matches neither service UUIDs nor service data', async () => {
+      const bindings = new DbusBindings();
+      const discoveries = [];
+      bindings.on('discover', (...args) => discoveries.push(args));
+
+      bindings.start();
+      await flush();
+      bindings.startScanning(['180d'], false);
+      await flush();
+
+      emitDevice({
+        UUIDs: ['0000feaa-0000-1000-8000-00805f9b34fb'],
+        ServiceData: { '0000feaa-0000-1000-8000-00805f9b34fb': v('ay', Buffer.from([0x01])) }
+      });
+      await flush();
+
+      expect(discoveries.length).toBe(0);
+    });
+
+    test('empty scan filter discovers everything', async () => {
+      const bindings = new DbusBindings();
+      const discoveries = [];
+      bindings.on('discover', (...args) => discoveries.push(args));
+
+      bindings.start();
+      await flush();
+      bindings.startScanning([], false);
+      await flush();
+
+      emitDevice({ UUIDs: ['0000feaa-0000-1000-8000-00805f9b34fb'] });
+      await flush();
+
+      expect(discoveries.length).toBe(1);
+    });
+  });
+
+  describe('connect failure recovery', () => {
+    const devicePath = '/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF';
+
+    function seedDevice () {
+      resetState(adapterTree({
+        [devicePath]: {
+          'org.bluez.Device1': { Address: 'AA:BB:CC:DD:EE:FF', AddressType: 'public', Connected: false }
+        }
+      }));
+    }
+
+    test('failed Connect emits connect(error), no disconnect, and clears the proxy', async () => {
+      seedDevice();
+      const proxy = makeProxy(devicePath);
+      proxy.getInterface('org.bluez.Device1').Connect = () => Promise.reject(new Error('le-connection-abort-by-local'));
+
+      const bindings = new DbusBindings();
+      const connects = [];
+      const disconnects = [];
+      bindings.on('connect', (id, err) => connects.push([id, err]));
+      bindings.on('disconnect', (id, reason) => disconnects.push([id, reason]));
+
+      bindings.start();
+      await flush();
+      bindings.connect('aabbccddeeff');
+      await flush();
+
+      expect(connects.length).toBe(1);
+      expect(connects[0][0]).toBe('aabbccddeeff');
+      expect(connects[0][1]).toBeInstanceOf(Error);
+
+      // Matches hci-socket: a failed attempt emits no 'disconnect'.
+      expect(disconnects.length).toBe(0);
+
+      // Proxy/listener released so a retry starts clean.
+      expect(bindings._devices.get('aabbccddeeff').proxy).toBeNull();
+    });
+
+    test('a remote drop mid-connect surfaces as connect(error), not disconnect', async () => {
+      seedDevice();
+      const proxy = makeProxy(devicePath);
+
+      const bindings = new DbusBindings();
+      const events = [];
+      bindings.on('connect', (id, err) => events.push(['connect', id, err]));
+      bindings.on('disconnect', (id, reason) => events.push(['disconnect', id, reason]));
+
+      bindings.start();
+      await flush();
+      bindings.connect('aabbccddeeff');
+      await flush();
+
+      const props = proxy.getInterface('org.freedesktop.DBus.Properties');
+      props.emit('PropertiesChanged', 'org.bluez.Device1', wrapDict({ Connected: false }));
+      await flush();
+
+      expect(events.length).toBe(1);
+      expect(events[0][0]).toBe('connect');
+      expect(events[0][2]).toBeInstanceOf(Error);
+    });
+
+    test('an established connection that drops emits a single disconnect', async () => {
+      resetState(adapterTree({
+        [devicePath]: {
+          'org.bluez.Device1': {
+            Address: 'AA:BB:CC:DD:EE:FF', AddressType: 'public', Connected: true, ServicesResolved: true
+          }
+        }
+      }));
+      const proxy = makeProxy(devicePath);
+
+      const bindings = new DbusBindings();
+      const connects = [];
+      const disconnects = [];
+      bindings.on('connect', (id, err) => connects.push([id, err]));
+      bindings.on('disconnect', (id, reason) => disconnects.push([id, reason]));
+
+      bindings.start();
+      await flush();
+      bindings.connect('aabbccddeeff');
+      await flush();
+      expect(connects.length).toBe(1);
+      expect(connects[0][1]).toBeNull();
+
+      const props = proxy.getInterface('org.freedesktop.DBus.Properties');
+      props.emit('PropertiesChanged', 'org.bluez.Device1', wrapDict({ Connected: false }));
+      await flush();
+
+      expect(disconnects.length).toBe(1);
+      expect(disconnects[0][0]).toBe('aabbccddeeff');
+    });
+  });
+
+  describe('late-arriving advertisement data during scan', () => {
+    const devicePath = '/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF';
+
+    test('a UUID that arrives in a later PropertiesChanged still triggers discover', async () => {
+      const bindings = new DbusBindings();
+      const discoveries = [];
+      bindings.on('discover', (...args) => discoveries.push(args));
+
+      bindings.start();
+      await flush();
+      bindings.startScanning(['180d'], false);
+      await flush();
+
+      // First sighting has no matching UUID -> tracked, not discovered.
+      const om = state.rootProxy.getInterface('org.freedesktop.DBus.ObjectManager');
+      om.emit('InterfacesAdded', devicePath, {
+        'org.bluez.Device1': wrapDict({ Address: 'AA:BB:CC:DD:EE:FF', AddressType: 'public', RSSI: -50 })
+      });
+      await flush();
+      expect(discoveries.length).toBe(0);
+
+      // BlueZ later aggregates the matching service data -> now discovered.
+      const props = makeProxy(devicePath).getInterface('org.freedesktop.DBus.Properties');
+      props.emit('PropertiesChanged', 'org.bluez.Device1', wrapDict({
+        ServiceData: { '0000180d-0000-1000-8000-00805f9b34fb': v('ay', Buffer.from([0x01])) }
+      }));
+      await flush();
+
+      expect(discoveries.length).toBe(1);
+      expect(discoveries[0][0]).toBe('aabbccddeeff');
+    });
+
+    test('a watcher suspended on getProxyObject across stopScanning does not re-attach', async () => {
+      const bindings = new DbusBindings();
+      bindings.start();
+      await flush();
+      bindings.startScanning([], false);
+      await flush();
+
+      // Park the watcher on getProxyObject, and keep _stopScanning suspended on
+      // StopDiscovery, so the watcher resumes mid-stop — the F1 race window.
+      let releaseWatch;
+      const watchGate = new Promise(resolve => { releaseWatch = resolve; });
+      mockBus.getProxyObject.mockImplementationOnce(async (_svc, path) => {
+        await watchGate;
+        return makeProxy(path);
+      });
+      let releaseStop;
+      const stopGate = new Promise(resolve => { releaseStop = resolve; });
+      makeProxy('/org/bluez/hci0').getInterface('org.bluez.Adapter1').StopDiscovery = () => stopGate;
+
+      const om = state.rootProxy.getInterface('org.freedesktop.DBus.ObjectManager');
+      om.emit('InterfacesAdded', devicePath, {
+        'org.bluez.Device1': wrapDict({ Address: 'AA:BB:CC:DD:EE:FF', AddressType: 'public' })
+      });
+      await flush(); // _watchDeviceProps parked on watchGate
+
+      bindings.stopScanning(); // _stopScanning parked on StopDiscovery
+      await flush();
+
+      releaseWatch(); // watcher resumes while stop is still in flight
+      await flush();
+
+      releaseStop();
+      await flush();
+
+      expect(bindings._scanPropsListeners.size).toBe(0);
+    });
+
+    test('scan-time watchers are detached on stopScanning', async () => {
+      const bindings = new DbusBindings();
+      bindings.start();
+      await flush();
+      bindings.startScanning([], false);
+      await flush();
+
+      const om = state.rootProxy.getInterface('org.freedesktop.DBus.ObjectManager');
+      om.emit('InterfacesAdded', devicePath, {
+        'org.bluez.Device1': wrapDict({ Address: 'AA:BB:CC:DD:EE:FF', AddressType: 'public' })
+      });
+      await flush();
+      expect(bindings._scanPropsListeners.size).toBe(1);
+
+      bindings.stopScanning();
+      await flush();
+      expect(bindings._scanPropsListeners.size).toBe(0);
+    });
+  });
 });


### PR DESCRIPTION
Closes #89.

Makes the D-Bus/BlueZ backend behave like the other noble backends (reference: `hci-socket`) for the two problems reported in #89.

## 1. Scan service-UUID filtering hid always-on devices

`SetDiscoveryFilter`'s `UUIDs` matches only advertised service UUIDs (AD 0x02/0x03), so always-on devices (e.g. some Ikea Matter/Thread devices) that carry their identity in *service data* (AD 0x16) were excluded entirely.

- Drop the BlueZ `UUIDs` filter; scan promiscuously and filter in software over both `serviceUuids` **and** `serviceData`, matching `hci-socket`.
- BlueZ commonly delivers `ServiceData`/`UUIDs` in a `PropertiesChanged` *after* the initial `InterfacesAdded`. The old server-side filter surfaced those; a naive software filter at first-sighting would not. So each device is now watched during scan and re-evaluated on every advertisement update.
- Advertisement is rebuilt from cumulative properties, so an RSSI-only update can't wipe previously-seen service UUIDs/data.

## 2. Failed connect left the peripheral stuck

On a connect failure the backend leaked the per-device proxy + `PropertiesChanged` listener.

- A failed attempt now emits `connect(error)` only and releases the proxy/listener so a retry starts clean — the peripheral stays in `error` and remains retryable, identical to `hci-socket` (which emits no `disconnect` on a failed attempt).
- An **established** connection that later drops still emits exactly one `disconnect`.

## Tests

Added dbus binding tests: software scan-filter matrix, late-arriving service data via `PropertiesChanged`, scan-watcher teardown + a suspended-watcher/stop-scan race, and connect-failure event/state behavior (no synthetic disconnect; single disconnect on a real drop). Full suite green, lint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)