### PR TITLE
fix(dbus): prevent unhandled rejection crash on remote drop during connect

### DIFF
--- a/lib/dbus/bindings.js
+++ b/lib/dbus/bindings.js
@@ -613,14 +613,15 @@ class DbusBindings extends EventEmitter {
       device.connectPromise = { resolve, reject };
     });
 
+    // Keep both in one await: split into sequential awaits and a mid-connect
+    // remote drop rejects waitConnected with no handler yet, crashing the process.
     try {
-      await iface.Connect();
+      await Promise.all([iface.Connect(), waitConnected]);
     } catch (err) {
       device.connectPromise = null;
       throw err;
     }
 
-    await waitConnected;
     this.emit('connect', id, null);
   }
 

--- a/test/lib/dbus/bindings.test.js
+++ b/test/lib/dbus/bindings.test.js
@@ -656,6 +656,42 @@ describe('dbus/bindings', () => {
       expect(events[0][2]).toBeInstanceOf(Error);
     });
 
+    test('remote drop while Connect() is in flight surfaces as connect(err), not an unhandled rejection (#91)', async () => {
+      seedDevice();
+      const proxy = makeProxy(devicePath);
+      // Keep Connect() pending so the drop lands while _connect is still
+      // awaiting the D-Bus call — the unhandled-rejection window from #91.
+      const device1 = proxy.getInterface('org.bluez.Device1');
+      device1.Connect = jest.fn().mockReturnValue(new Promise(() => {}));
+
+      const unhandled = [];
+      const onUnhandled = err => unhandled.push(err);
+      process.on('unhandledRejection', onUnhandled);
+      try {
+        const bindings = new DbusBindings();
+        const connects = [];
+        bindings.on('connect', (...a) => connects.push(a));
+
+        bindings.start();
+        await flush();
+        bindings.connect('aabbccddeeff');
+        await flush();
+        expect(device1.Connect).toHaveBeenCalled();
+
+        const props = proxy.getInterface('org.freedesktop.DBus.Properties');
+        props.emit('PropertiesChanged', 'org.bluez.Device1', wrapDict({ Connected: false }));
+        await flush();
+
+        expect(connects.length).toBe(1);
+        expect(connects[0][0]).toBe('aabbccddeeff');
+        expect(connects[0][1]).toBeInstanceOf(Error);
+        expect(connects[0][1].message).toMatch(/disconnected: remote/);
+        expect(unhandled).toEqual([]);
+      } finally {
+        process.off('unhandledRejection', onUnhandled);
+      }
+    });
+
     test('an established connection that drops emits a single disconnect', async () => {
       resetState(adapterTree({
         [devicePath]: {


### PR DESCRIPTION
## Problem

Reported in #91. On a Raspberry Pi DBus backend (matter BLE commissioning), a peripheral disconnecting mid-connect crashes the whole Node process:

```
disconnected: remote at DbusBindings._onDeviceDisconnected (lib/dbus/bindings.js:497:36)
```

`_onDeviceDisconnected` rejects `device.connectPromise` to turn a drop-while-connecting into a connect failure. But `_connect` awaited the two things sequentially:

```js
await iface.Connect();   // suspends here for the duration of the D-Bus call
await waitConnected;      // handler for connectPromise attached ONLY here
```

While `iface.Connect()` is in flight, `waitConnected` has no handler attached. A `PropertiesChanged Connected=false` arriving in that window rejects it → Node sees an unhandled rejection → the process terminates instead of the error propagating to awaiting code.

## Fix

Await both together with `Promise.all`, which attaches `.then` to each input synchronously at creation. A mid-flight reject is now handled, `Promise.all` rejects, and it flows to `connect()`'s existing `.catch`, emitting a normal `connect(err)`.

```js
try {
  await Promise.all([iface.Connect(), waitConnected]);
} catch (err) {
  device.connectPromise = null;
  throw err;
}
```

## Test

Adds a regression test: a `Connect()` that stays pending, then a remote `Connected=false` while it is in flight. Asserts a single `connect(err)` (`disconnected: remote`) and **zero** `unhandledRejection` events. Verified the test fails on the pre-fix code (0 connect events, rejection lost) and passes with the fix. Full dbus suite green (44), full suite green (675).

Note: the `fix/dbus-issue-89` work carries the same sequential-await pattern, so the crash survives there too — worth folding this in when that lands.

Fixes #91

🤖 Generated with [Claude Code](https://claude.com/claude-code)