### PR TITLE
fix(win): drop /await and silence experimental coroutine deprecation

### DIFF
--- a/lib/win/binding.gyp
+++ b/lib/win/binding.gyp
@@ -19,7 +19,6 @@
         'VCCLCompilerTool': {
           'ExceptionHandling': 1,
           'AdditionalOptions': [
-            '/await', 
             '/std:c++20'
           ],
         },
@@ -28,7 +27,7 @@
       'msvs_target_platform_minversion':'10.0.18362.0',
       'conditions': [
         ['OS=="win"', { 
-          'defines': [ '_HAS_EXCEPTIONS=1', 'NAPI_CPP_EXCEPTIONS' ] 
+          'defines': [ '_HAS_EXCEPTIONS=1', 'NAPI_CPP_EXCEPTIONS', '_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS' ] 
         }]
       ],
     }


### PR DESCRIPTION
## Summary

- Remove `/await` from Windows `binding.gyp` `AdditionalOptions` (redundant/conflicting under `/std:c++20`).
- Add `_SILENCE_EXPERIMENTAL_COROUTINE_DEPRECATION_WARNINGS` alongside existing N-API exception defines.

## Context

Colorado-Mesh/mesh-client carries this as a pnpm patch against `@stoprocent/noble@2.5.7` so Electron native rebuilds on Windows succeed with current MSVC toolsets.

## Test plan

- [ ] `npm install` / rebuild native bindings on Windows with a recent VS/MSVC toolchain
- [ ] Confirm BLE scan/connect still works after rebuild