### PR TITLE
fix(types): expose HCI disconnect reason messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,21 @@ const data = await peripheral.readHandleAsync(handle);
 await peripheral.writeHandleAsync(handle, data, withoutResponse);
 ```
 
+The Linux HCI binding reports controller disconnect reasons as numeric HCI
+status codes. Other bindings and library cleanup paths may report a string.
+Use `hciStatusMessage` when a human-readable HCI message is needed:
+
+```typescript
+import noble, { hciStatusMessage } from '@stoprocent/noble';
+
+peripheral.on('disconnect', reason => {
+  const message = typeof reason === 'number'
+    ? hciStatusMessage(reason)
+    : reason;
+  console.log(`Disconnected: ${message}`);
+});
+```
+
 ### Service Methods
 
 ```typescript

--- a/index.d.ts
+++ b/index.d.ts
@@ -17,6 +17,12 @@ declare module '@stoprocent/noble' {
 
     export type PeripheralIdOrAddress = string;
 
+    /**
+     * Linux HCI bindings emit the numeric controller status. Other bindings
+     * and library-initiated cleanup paths emit a descriptive string.
+     */
+    export type DisconnectReason = number | string;
+
     export type CharacteristicProperty = 'read' | 'write' | 'indicate' | 'notify' | 'writeWithoutResponse';
 
     export interface ConnectOptions {
@@ -122,14 +128,14 @@ declare module '@stoprocent/noble' {
         toString(): string;
     
         on(event: "connect", listener: (error: Error | undefined) => void): this;
-        on(event: "disconnect", listener: (reason: string) => void): this;
+        on(event: "disconnect", listener: (reason: DisconnectReason) => void): this;
         on(event: "rssiUpdate", listener: (rssi: number) => void): this;
         on(event: "servicesDiscover", listener: (services: Service[]) => void): this;
         on(event: "mtu", listener: (mtu: number) => void): this;
         on(event: string, listener: Function): this;
     
         once(event: "connect", listener: (error: Error | undefined) => void): this;
-        once(event: "disconnect", listener: (reason: string) => void): this;
+        once(event: "disconnect", listener: (reason: DisconnectReason) => void): this;
         once(event: "rssiUpdate", listener: (rssi: number) => void): this;
         once(event: "servicesDiscover", listener: (services: Service[]) => void): this;
         once(event: string, listener: Function): this;
@@ -256,6 +262,9 @@ declare module '@stoprocent/noble' {
         bindingType?: BindingType, 
         options?: WithBindingsOptions
     ): Noble;
+
+    /** Resolve a numeric HCI status code to its Bluetooth specification message. */
+    export function hciStatusMessage(reason: DisconnectReason): string;
 
     // Define a default export
     const NobleDefault: Noble;

--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 const withBindings = require('./lib/resolve-bindings');
+const hciStatusMessage = require('./lib/hci-status-message');
 
 module.exports = withBindings();
 module.exports.withBindings = withBindings;
+module.exports.hciStatusMessage = hciStatusMessage;

--- a/lib/hci-status-message.js
+++ b/lib/hci-status-message.js
@@ -1,0 +1,17 @@
+const hciStatus = require('./hci-socket/hci-status');
+
+module.exports = function hciStatusMessage (reason) {
+  if (typeof reason !== 'number') {
+    return String(reason);
+  }
+
+  if (hciStatus[reason]) {
+    return hciStatus[reason];
+  }
+
+  const code = Number.isInteger(reason)
+    ? `0x${reason.toString(16).padStart(2, '0')}`
+    : String(reason);
+
+  return `Unknown HCI status (${code})`;
+};

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "node": ">=14"
       },
       "optionalDependencies": {
-        "@stoprocent/bluetooth-hci-socket": "^2.2.6"
+        "@stoprocent/bluetooth-hci-socket": "^2.2.8"
       },
       "peerDependencies": {
         "dbus-next": "^0.10.0"
@@ -3086,9 +3086,9 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@stoprocent/bluetooth-hci-socket": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.2.6.tgz",
-      "integrity": "sha512-elKIsQe78EnxXzxfA/iuqGufD02d6t3S95eNhFaPvTJs7S3IHq2CdIHwTg3BLwae7Jw14mwK0VhWVtNtzrLyoA==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.2.8.tgz",
+      "integrity": "sha512-Nbnj3ZoDMHCGU9p4t+tZbPJp7tbyCaPF4o1qcpegUZKauQi12wqLjYv3GPZmNSpgM/5kmtEq9PpfxCM3w6AT7g==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "patch-package": "^8.0.0"
   },
   "optionalDependencies": {
-    "@stoprocent/bluetooth-hci-socket": "^2.2.6"
+    "@stoprocent/bluetooth-hci-socket": "^2.2.8"
   },
   "peerDependencies": {
     "dbus-next": "^0.10.0"

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -1,0 +1,11 @@
+jest.mock('../lib/resolve-bindings', () => jest.fn(() => ({})));
+
+const noble = require('../index');
+
+describe('public exports', () => {
+  test('exposes the HCI status message helper', () => {
+    expect(noble.hciStatusMessage(0x3e)).toBe(
+      'Connection Failed to be Established'
+    );
+  });
+});

--- a/test/lib/hci-status-message.test.js
+++ b/test/lib/hci-status-message.test.js
@@ -1,0 +1,15 @@
+const hciStatusMessage = require('../../lib/hci-status-message');
+
+describe('hciStatusMessage', () => {
+  test('resolves a known numeric HCI status', () => {
+    expect(hciStatusMessage(0x3e)).toBe('Connection Failed to be Established');
+  });
+
+  test('preserves string disconnect reasons', () => {
+    expect(hciStatusMessage('cleanup')).toBe('cleanup');
+  });
+
+  test('includes an unknown numeric status in the fallback', () => {
+    expect(hciStatusMessage(0xff)).toBe('Unknown HCI status (0xff)');
+  });
+});


### PR DESCRIPTION
## What changed

- declare disconnect reasons as `number | string`, matching the values emitted by all bindings
- export `hciStatusMessage(reason)` for resolving numeric HCI status codes
- document the cross-platform disconnect reason behavior
- add focused public-export and formatter tests

## Why

The Linux HCI binding emits the controller's raw numeric disconnect status, while other bindings and cleanup paths emit strings. The public TypeScript declaration only allowed `string`, so valid Linux values could cause runtime failures in code written against the declared API.

This keeps the runtime event shape unchanged for backward compatibility. A structured disconnect object can be considered separately for a future major release.

## Validation

- `npx jest --runInBand` — 689 passed, 1 skipped
- `npm run lint`
- `git diff --check`

Fixes #100
