### PR TITLE
fix(hci): enable and document Linux user channel

### DIFF
--- a/README.md
+++ b/README.md
@@ -567,6 +567,48 @@ See [@don](https://github.com/don)'s setup guide on [Bluetooth LE with Node.js a
 
 Make sure your container runs with `--network=host` options and all specific environment prerequisites are verified.
 
+### Choosing a Linux Bluetooth access mode
+
+Noble supports three materially different Linux setups:
+
+- **D-Bus binding:** `withBindings('dbus')` uses the system BlueZ service and
+  is the best default when noble should coexist with desktop or system
+  Bluetooth clients.
+- **Raw HCI binding:** `withBindings('hci')` is the default on Linux. It shares
+  the controller with the kernel Bluetooth stack and BlueZ. It requires raw
+  socket privileges and gives noble direct access to HCI traffic.
+- **HCI user channel:** `withBindings('hci', { userChannel: true })` gives noble
+  exclusive controller access. Use it for a dedicated adapter when another
+  Bluetooth stack must not operate that controller.
+
+The user channel requires `CAP_NET_ADMIN` (running with `sudo` is the simplest
+setup) and the adapter must be down before noble binds it:
+
+```sh
+sudo hciconfig hci1 down
+sudo NOBLE_HCI_DEVICE_ID=1 HCI_CHANNEL_USER=1 node app.js
+```
+
+The equivalent code configuration is:
+
+```typescript
+const noble = withBindings('hci', {
+  hciDriver: 'native',
+  deviceId: 1,
+  userChannel: true
+});
+```
+
+Binding the user channel to an adapter that is still up fails with `EBUSY`.
+Conversely, raw mode does not power up a down adapter; run
+`sudo hciconfig hciX up` first when using raw mode.
+
+When diagnosing raw-mode traffic with `btmon`, an unlabeled HCI command only
+shows that the kernel sent it. It is not, by itself, proof that `bluetoothd`
+started an unrelated operation: noble's native HCI dependency also uses kernel
+L2CAP sockets for connection bookkeeping. Use a dedicated adapter with the
+user channel when command ownership must be unambiguous.
+
 ### Running without root/sudo (Linux-specific)
 
 Run the following command:
@@ -585,7 +627,9 @@ It can be installed the following way:
 
 ### Multiple Adapters (Linux-specific)
 
-`hci0` is used by default.
+When no adapter is specified, raw mode selects the first adapter that is up,
+while the user channel selects the first adapter that is down. Specify the
+adapter explicitly whenever more than one is present.
 
 You can specify which HCI adapter to use in two ways:
 
@@ -644,6 +688,7 @@ The following environment variables can configure noble's behavior:
 | Variable | Purpose | Default | Example |
 |----------|---------|---------|---------|
 | NOBLE_HCI_DEVICE_ID | Specify which HCI adapter to use | 0 | `export NOBLE_HCI_DEVICE_ID=1` |
+| HCI_CHANNEL_USER | Use the exclusive Linux HCI user channel | false | `export HCI_CHANNEL_USER=1` |
 | NOBLE_REPORT_ALL_HCI_EVENTS | Report HCI events without waiting for scan response | false | `export NOBLE_REPORT_ALL_HCI_EVENTS=1` |
 | BLUETOOTH_HCI_SOCKET_UART_PORT | UART port for HCI communication | none | `export BLUETOOTH_HCI_SOCKET_UART_PORT=/dev/ttyUSB0` |
 | BLUETOOTH_HCI_SOCKET_UART_BAUDRATE | UART baudrate | 1000000 | `export BLUETOOTH_HCI_SOCKET_UART_BAUDRATE=1000000` |

--- a/index.d.ts
+++ b/index.d.ts
@@ -243,7 +243,10 @@ declare module '@stoprocent/noble' {
         deviceId?: number;
         /** Use With BLE5 Extended Features, Default is based on the result of LE_READ_LOCAL_SUPPORTED_FEATURES command */
         extended?: boolean;
-        /** Uses User channel instead of Raw HCI Channel */
+        /**
+         * Use the exclusive Linux HCI user channel instead of the shared raw
+         * channel. The selected adapter must be down before binding.
+         */
         userChannel?: boolean;
     }
 

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -142,9 +142,9 @@ const Hci = function (options) {
       ? parseInt(process.env.NOBLE_HCI_DEVICE_ID, 10)
       : undefined;
 
-  this._userChannel =
-    (typeof options.userChannel === 'undefined' && options.userChannel) ||
-    process.env.HCI_CHANNEL_USER;
+  this._userChannel = typeof options.userChannel !== 'undefined'
+    ? options.userChannel
+    : Boolean(process.env.HCI_CHANNEL_USER);
 
   this.on('stateChange', this.onStateChange.bind(this));
 };

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "node": ">=14"
       },
       "optionalDependencies": {
-        "@stoprocent/bluetooth-hci-socket": "^2.2.6"
+        "@stoprocent/bluetooth-hci-socket": "^2.2.8"
       },
       "peerDependencies": {
         "dbus-next": "^0.10.0"
@@ -3086,9 +3086,9 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@stoprocent/bluetooth-hci-socket": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.2.6.tgz",
-      "integrity": "sha512-elKIsQe78EnxXzxfA/iuqGufD02d6t3S95eNhFaPvTJs7S3IHq2CdIHwTg3BLwae7Jw14mwK0VhWVtNtzrLyoA==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.2.8.tgz",
+      "integrity": "sha512-Nbnj3ZoDMHCGU9p4t+tZbPJp7tbyCaPF4o1qcpegUZKauQi12wqLjYv3GPZmNSpgM/5kmtEq9PpfxCM3w6AT7g==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "patch-package": "^8.0.0"
   },
   "optionalDependencies": {
-    "@stoprocent/bluetooth-hci-socket": "^2.2.6"
+    "@stoprocent/bluetooth-hci-socket": "^2.2.8"
   },
   "peerDependencies": {
     "dbus-next": "^0.10.0"

--- a/test/lib/hci-socket/hci.test.js
+++ b/test/lib/hci-socket/hci.test.js
@@ -41,6 +41,42 @@ describe('hci-socket hci', () => {
     sinon.reset();
   });
 
+  describe('user channel configuration', () => {
+    const originalUserChannel = process.env.HCI_CHANNEL_USER;
+
+    afterEach(() => {
+      if (typeof originalUserChannel === 'undefined') {
+        delete process.env.HCI_CHANNEL_USER;
+      } else {
+        process.env.HCI_CHANNEL_USER = originalUserChannel;
+      }
+    });
+
+    it('uses the userChannel option', () => {
+      delete process.env.HCI_CHANNEL_USER;
+
+      const configuredHci = new Hci({ userChannel: true });
+
+      should(configuredHci._userChannel).be.true();
+    });
+
+    it('allows the option to disable an environment setting', () => {
+      process.env.HCI_CHANNEL_USER = '1';
+
+      const configuredHci = new Hci({ userChannel: false });
+
+      should(configuredHci._userChannel).be.false();
+    });
+
+    it('uses HCI_CHANNEL_USER when the option is omitted', () => {
+      process.env.HCI_CHANNEL_USER = '1';
+
+      const configuredHci = new Hci({});
+
+      should(configuredHci._userChannel).be.true();
+    });
+  });
+
   describe('init', () => {
     it('should reset', () => {
       hci.reset = sinon.spy();


### PR DESCRIPTION
## What changed

- make the documented `userChannel` option take effect and allow an explicit `false` to override the environment
- test option and `HCI_CHANNEL_USER` precedence
- document the D-Bus, raw HCI, and exclusive HCI user-channel modes
- document the user-channel `CAP_NET_ADMIN` and adapter-down prerequisites
- explain raw/user adapter auto-selection and recommend an explicit device ID with multiple adapters
- clarify that an unlabeled `btmon` command proves kernel origin, not which userspace request caused it

## Why

`HCI_CHANNEL_USER` was supported but undocumented, while the typed `userChannel` option was ignored because its selection condition was inverted. That made the reliable exclusive-adapter setup difficult to discover and impossible to select through `withBindings()`.

Raw mode also uses kernel L2CAP sockets inside `@stoprocent/bluetooth-hci-socket`, so unlabeled kernel commands cannot safely be attributed to an unrelated BlueZ operation from the `btmon` prefix alone. The troubleshooting guidance calls out that limitation instead of encoding a misleading diagnosis.

## Validation

- `npx jest --runInBand` — 688 passed, 1 skipped
- `npm run lint`
- `git diff --check`

Fixes #101
