### PR TITLE
fix(noble): resume async discovery after connect

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,10 +89,8 @@ import noble from '@stoprocent/noble';
 try {
   // Wait for Adapter poweredOn state
   await noble.waitForPoweredOnAsync();
-  // Start scanning first
-  await noble.startScanningAsync();
-  
-  // Use the async generator with proper boundaries
+
+  // discoverAsync starts and owns the scanning session
   for await (const peripheral of noble.discoverAsync()) {
     console.log(`Found device: ${peripheral.advertisement.localName || 'Unknown'}`);
     // Process the peripheral as needed
@@ -103,13 +101,15 @@ try {
     }
   }
   
-  // Clean up after discovery
-  await noble.stopScanningAsync();
 } catch (error) {
   console.error('Discovery error:', error);
   await noble.stopScanningAsync();
 }
 ```
+
+`discoverAsync()` resumes scanning after temporary binding-level pauses, such
+as the Linux HCI binding stopping scan while it connects. Break the loop or
+call `stopScanning()` / `stopScanningAsync()` to end the discovery session.
 
 For a more detailed example, please check out [examples/peripheral-explorer.ts](examples/peripheral-explorer.ts)
 
@@ -320,7 +320,8 @@ await noble.startScanningAsync(serviceUUIDs?: string[], allowDuplicates?: boolea
 // Stop scanning
 await noble.stopScanningAsync();
 
-// Discover peripherals as an async generator
+// Discover peripherals as an async generator. This starts scanning and
+// resumes temporary binding-level scan pauses until the loop is stopped.
 for await (const peripheral of noble.discoverAsync()) {
   // handle each discovered peripheral
 }

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -17,6 +17,7 @@ class Noble extends NobleEventEmitter {
     
     this._initialized = false;
     this._bindings = bindings;
+    this._scanStopRequestId = 0;
 
     this._discoveredPeripherals = new Set();
     this._peripherals = new Map();
@@ -234,6 +235,7 @@ class Noble extends NobleEventEmitter {
       callback(new Error('Bindings are not initialized'));
       return;
     }
+    this._scanStopRequestId += 1;
     if (callback) {
       this.onceExclusive('scanStop', callback);
     }
@@ -248,70 +250,70 @@ class Noble extends NobleEventEmitter {
 
   async *discoverAsync () {
     const deviceQueue = [];
-    let scanning = true;
-    
-    // Main discover listener to add devices to the queue
-    const discoverListener = peripheral => deviceQueue.push(peripheral);
-    
-    // State change listener
-    const scanStopListener = () => scanning = false;
-    
-    // Set up listeners
+    const scanStopRequestId = this._scanStopRequestId;
+    let scanning = false;
+    let resolveActivity = null;
+
+    const signalActivity = () => {
+      if (resolveActivity) {
+        const resolve = resolveActivity;
+        resolveActivity = null;
+        resolve();
+      }
+    };
+    const discoverListener = peripheral => {
+      deviceQueue.push(peripheral);
+      signalActivity();
+    };
+    const scanStartListener = () => {
+      scanning = true;
+      signalActivity();
+    };
+    const scanStopListener = () => {
+      scanning = false;
+      signalActivity();
+    };
+    const stateChangeListener = () => signalActivity();
+    const discoveryShouldContinue = () =>
+      this._scanStopRequestId === scanStopRequestId &&
+      this._state === 'poweredOn';
+    const waitForActivity = () => new Promise(resolve => {
+      resolveActivity = resolve;
+      if (deviceQueue.length > 0 || !scanning || !discoveryShouldContinue()) {
+        signalActivity();
+      }
+    });
+
     this.on('discover', discoverListener);
-    this.once('scanStop', scanStopListener);
-    
+    this.on('scanStart', scanStartListener);
+    this.on('scanStop', scanStopListener);
+    this.on('stateChange', stateChangeListener);
+
     try {
-        // Start the scanning process
-        await this.startScanningAsync();
-        
-        // Process discovered devices
-        while (scanning || deviceQueue.length > 0) {
-            if (deviceQueue.length > 0) {
-                // If we have devices in the queue, yield them
-                yield deviceQueue.shift();
-            } else if (scanning) {
-                // Wait for either a new device or scan stop
-                await new Promise(resolve => {
-                    let resolved = false;
-                    let timeoutId = null;
+      await this.startScanningAsync();
 
-                    const cleanup = () => {
-                        if (resolved) return;
-                        resolved = true;
-                        this.removeListener('discover', tempDiscoverListener);
-                        this.removeListener('scanStop', tempScanStopListener);
-                        if (timeoutId) clearTimeout(timeoutId);
-                        resolve();
-                    };
-
-                    const tempDiscoverListener = () => cleanup();
-                    const tempScanStopListener = () => cleanup();
-
-                    this.once('discover', tempDiscoverListener);
-                    this.once('scanStop', tempScanStopListener);
-
-                    // Handle race condition where a device might arrive during promise setup
-                    if (deviceQueue.length > 0) {
-                        cleanup();
-                        return;
-                    }
-
-                    // Add a maximum wait time with proper cleanup
-                    if (scanning) {
-                        timeoutId = setTimeout(() => cleanup(), 1000);
-                    }
-                });
-            }
+      while (discoveryShouldContinue()) {
+        if (deviceQueue.length > 0) {
+          yield deviceQueue.shift();
+        } else if (!scanning) {
+          // HCI bindings temporarily stop scanning before a connection. Resume
+          // the discovery session after the consumer finishes handling the
+          // yielded peripheral.
+          await this.startScanningAsync();
+        } else {
+          await waitForActivity();
         }
+      }
     } finally {
-        // Clean up listeners
-        this.removeListener('discover', discoverListener);
-        this.removeListener('scanStop', scanStopListener);
-        
-        // Ensure scanning is stopped
-        if (scanning) {
-            await this.stopScanningAsync();
-        }
+      this.removeListener('discover', discoverListener);
+      this.removeListener('scanStart', scanStartListener);
+      this.removeListener('scanStop', scanStopListener);
+      this.removeListener('stateChange', stateChangeListener);
+      signalActivity();
+
+      if (scanning && discoveryShouldContinue()) {
+        await this.stopScanningAsync();
+      }
     }
   }
 
@@ -326,6 +328,7 @@ class Noble extends NobleEventEmitter {
   }
 
   stop () {
+    this._scanStopRequestId += 1;
     if (typeof this._bindings.stop !== 'function') { return; }
     this._bindings.stop();
   }

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -252,6 +252,8 @@ class Noble extends NobleEventEmitter {
     const deviceQueue = [];
     const scanStopRequestId = this._scanStopRequestId;
     let scanning = false;
+    let scanStopVersion = 0;
+    let resumedScanStopVersion = 0;
     let resolveActivity = null;
 
     const signalActivity = () => {
@@ -271,6 +273,7 @@ class Noble extends NobleEventEmitter {
     };
     const scanStopListener = () => {
       scanning = false;
+      scanStopVersion += 1;
       signalActivity();
     };
     const stateChangeListener = () => signalActivity();
@@ -291,9 +294,17 @@ class Noble extends NobleEventEmitter {
 
     try {
       await this.startScanningAsync();
+      resumedScanStopVersion = scanStopVersion;
 
       while (discoveryShouldContinue()) {
-        if (deviceQueue.length > 0) {
+        if (resumedScanStopVersion < scanStopVersion) {
+          // HCI connection setup can briefly emit scanStart after stopping the
+          // discovery scan, without a matching scanStop. Track observed stops
+          // independently so that transient event cannot suppress the restart.
+          const stoppedThroughVersion = scanStopVersion;
+          await this.startScanningAsync();
+          resumedScanStopVersion = stoppedThroughVersion;
+        } else if (deviceQueue.length > 0) {
           yield deviceQueue.shift();
         } else if (!scanning) {
           // HCI bindings temporarily stop scanning before a connection. Resume

--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "node": ">=14"
       },
       "optionalDependencies": {
-        "@stoprocent/bluetooth-hci-socket": "^2.2.6"
+        "@stoprocent/bluetooth-hci-socket": "^2.2.8"
       },
       "peerDependencies": {
         "dbus-next": "^0.10.0"
@@ -3086,9 +3086,9 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@stoprocent/bluetooth-hci-socket": {
-      "version": "2.2.6",
-      "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.2.6.tgz",
-      "integrity": "sha512-elKIsQe78EnxXzxfA/iuqGufD02d6t3S95eNhFaPvTJs7S3IHq2CdIHwTg3BLwae7Jw14mwK0VhWVtNtzrLyoA==",
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.2.8.tgz",
+      "integrity": "sha512-Nbnj3ZoDMHCGU9p4t+tZbPJp7tbyCaPF4o1qcpegUZKauQi12wqLjYv3GPZmNSpgM/5kmtEq9PpfxCM3w6AT7g==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "patch-package": "^8.0.0"
   },
   "optionalDependencies": {
-    "@stoprocent/bluetooth-hci-socket": "^2.2.6"
+    "@stoprocent/bluetooth-hci-socket": "^2.2.8"
   },
   "peerDependencies": {
     "dbus-next": "^0.10.0"

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -266,7 +266,7 @@ describe('noble', () => {
       expect(mockBindings.stopScanning).toHaveBeenCalledTimes(1);
     });
 
-    test('resumes after a binding-level scan pause', async () => {
+    test('resumes after a binding-level scan pause with a transient scan start', async () => {
       const firstPeripheral = { id: 'first' };
       const secondPeripheral = { id: 'second' };
       const first = iterator.next();
@@ -276,6 +276,10 @@ describe('noble', () => {
       // The HCI binding stops scanning internally before connecting. This does
       // not pass through Noble.stopScanning(), so it must remain resumable.
       noble._onScanStop();
+
+      // LE connection setup can briefly enable controller scanning and emit a
+      // scanStart without a matching scanStop. It is not the discovery scan.
+      noble._onScanStart();
 
       const second = iterator.next();
       await Promise.resolve();

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -14,6 +14,7 @@ describe('noble', () => {
   beforeEach(() => {
     mockBindings = {
       start: jest.fn(),
+      stop: jest.fn(),
       on: jest.fn(),
       startScanning: jest.fn(),
       stopScanning: jest.fn(),
@@ -230,6 +231,106 @@ describe('noble', () => {
       await expect(promise).resolves.toBeUndefined();
       expect(mockBindings.stopScanning).toHaveBeenCalled();
       expect(mockBindings.stopScanning).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('discoverAsync', () => {
+    let iterator;
+
+    beforeEach(() => {
+      noble._initialized = true;
+      noble._state = 'poweredOn';
+      mockBindings.startScanning.mockImplementation(() => noble._onScanStart());
+      mockBindings.stopScanning.mockImplementation(() => noble._onScanStop());
+      iterator = noble.discoverAsync();
+    });
+
+    afterEach(async () => {
+      await iterator.return();
+    });
+
+    test('yields discovered peripherals and stops scanning when returned', async () => {
+      const peripheral = { id: 'first' };
+      const nextPeripheral = iterator.next();
+
+      noble.emit('discover', peripheral);
+
+      await expect(nextPeripheral).resolves.toEqual({
+        value: peripheral,
+        done: false
+      });
+
+      await iterator.return();
+
+      expect(mockBindings.startScanning).toHaveBeenCalledTimes(1);
+      expect(mockBindings.stopScanning).toHaveBeenCalledTimes(1);
+    });
+
+    test('resumes after a binding-level scan pause', async () => {
+      const firstPeripheral = { id: 'first' };
+      const secondPeripheral = { id: 'second' };
+      const first = iterator.next();
+      noble.emit('discover', firstPeripheral);
+      await first;
+
+      // The HCI binding stops scanning internally before connecting. This does
+      // not pass through Noble.stopScanning(), so it must remain resumable.
+      noble._onScanStop();
+
+      const second = iterator.next();
+      await Promise.resolve();
+      noble.emit('discover', secondPeripheral);
+
+      await expect(second).resolves.toEqual({
+        value: secondPeripheral,
+        done: false
+      });
+      expect(mockBindings.startScanning).toHaveBeenCalledTimes(2);
+    });
+
+    test('ends after an explicit stopScanningAsync call', async () => {
+      const first = iterator.next();
+      noble.emit('discover', { id: 'first' });
+      await first;
+
+      await noble.stopScanningAsync();
+
+      await expect(iterator.next()).resolves.toEqual({
+        value: undefined,
+        done: true
+      });
+      expect(mockBindings.startScanning).toHaveBeenCalledTimes(1);
+      expect(mockBindings.stopScanning).toHaveBeenCalledTimes(1);
+    });
+
+    test('ends after Noble is stopped', async () => {
+      const first = iterator.next();
+      noble.emit('discover', { id: 'first' });
+      await first;
+
+      noble.stop();
+
+      await expect(iterator.next()).resolves.toEqual({
+        value: undefined,
+        done: true
+      });
+      expect(mockBindings.startScanning).toHaveBeenCalledTimes(1);
+      expect(mockBindings.stop).toHaveBeenCalledTimes(1);
+    });
+
+    test('ends instead of restarting when the adapter powers off', async () => {
+      const first = iterator.next();
+      noble.emit('discover', { id: 'first' });
+      await first;
+
+      noble._onScanStop();
+      noble._onStateChange('poweredOff');
+
+      await expect(iterator.next()).resolves.toEqual({
+        value: undefined,
+        done: true
+      });
+      expect(mockBindings.startScanning).toHaveBeenCalledTimes(1);
     });
   });
 


### PR DESCRIPTION
## What

- keep `discoverAsync()` alive across binding-level scan pauses
- resume scanning when the consumer requests the next peripheral after a connection
- distinguish explicit `stopScanning()` / `stop()` calls from internal HCI scan stops
- terminate cleanly on loop return or adapter power loss
- document that the async generator owns its scanning session

## Why

The Linux HCI binding stops scanning before creating a connection. `discoverAsync()` treated that internal pause as the end of the generator, so Raspberry Pi consumers exited after handling the first peripheral.

## Impact

The event-based discovery API is unchanged. Async-generator consumers now continue discovering after connecting, while explicit stops remain terminal.

## Validation

- `npx jest --runInBand` — 690 passed, 1 skipped
- `npm run lint`
- `git diff --check`

Fixes #29
