### PR TITLE
feat(win): add BLE pairing API and auto-accept Just Works confirmation

### DIFF
--- a/lib/common/include/Emit.h
+++ b/lib/common/include/Emit.h
@@ -17,6 +17,7 @@ public:
     void ScanState(bool start);
     void Scan(const std::string& uuid, int rssi, const Peripheral& peripheral);
     void Connected(const std::string& uuid, const std::string& error = "");
+    void Paired(const std::string& uuid, bool paired, const std::string& error = "");
     void Disconnected(const std::string& uuid);
     void MTU(const std::string& uuid, int mtu);
     void RSSI(const std::string& uuid, int rssi, const std::string& error = "");

--- a/lib/common/src/Emit.cc
+++ b/lib/common/src/Emit.cc
@@ -154,6 +154,14 @@ void Emit::Connected(const std::string& uuid, const std::string& error)
     });
 }
 
+void Emit::Paired(const std::string& uuid, bool paired, const std::string& error)
+{
+    mCallback->call([uuid, paired, error](Napi::Env env, std::vector<napi_value>& args) {
+        // emit('pair', deviceUuid, paired, error)
+        args = { _s("pair"), _u(uuid), _b(paired), error.empty() ? env.Null() : _e(error) };
+    });
+}
+
 void Emit::Disconnected(const std::string& uuid)
 {
     mCallback->call([uuid](Napi::Env env, std::vector<napi_value>& args) {

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -62,6 +62,7 @@ class Noble extends NobleEventEmitter {
     this._bindings.on('scanStop', this._onScanStop.bind(this));
     this._bindings.on('discover', this._onDiscover.bind(this));
     this._bindings.on('connect', this._onConnect.bind(this));
+    this._bindings.on('pair', this._onPair.bind(this));
     this._bindings.on('disconnect', this._onDisconnect.bind(this));
     this._bindings.on('rssiUpdate', this._onRssiUpdate.bind(this));
     this._bindings.on('servicesDiscover', this._onServicesDiscover.bind(this));
@@ -417,6 +418,32 @@ class Noble extends NobleEventEmitter {
       peripheral.emit('connect', error);
     } else {
       this.emit('warning', `unknown peripheral ${peripheralId} connected!`);
+    }
+  }
+
+  pair (idOrAddress, callback) {
+    const identifier = this._getPeripheralId(idOrAddress);
+    if (typeof callback === 'function') {
+      this.onceExclusive(`pair:${identifier}`, error => callback(error));
+    }
+    this._bindings.pair(identifier);
+  }
+
+  async pairAsync (idOrAddress) {
+    return new Promise((resolve, reject) => {
+      this.pair(idOrAddress, error => error ? reject(error) : resolve());
+    });
+  }
+
+  _onPair (peripheralId, paired, error) {
+    const peripheral = this._peripherals.get(peripheralId);
+    const failure = error || (paired ? null : new Error('pairing failed'));
+
+    if (peripheral) {
+      this.emit(`pair:${peripheralId}`, failure);
+      peripheral.emit('pair', failure);
+    } else {
+      this.emit('warning', `unknown peripheral ${peripheralId} paired!`);
     }
   }
 

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -426,6 +426,19 @@ class Noble extends NobleEventEmitter {
     if (typeof callback === 'function') {
       this.onceExclusive(`pair:${identifier}`, error => callback(error));
     }
+    if (typeof this._bindings.pair !== 'function') {
+      // Only the Windows bindings implement pairing today. Surface a
+      // deterministic error via the same event the callback waits on, so
+      // callers don't hang waiting for a 'pair' completion that will
+      // never come.
+      const err = new Error('Pairing is not supported on this platform');
+      const peripheral = this._peripherals.get(identifier);
+      if (peripheral) {
+        peripheral.emit('pair', err);
+      }
+      this.emit(`pair:${identifier}`, err);
+      return;
+    }
     this._bindings.pair(identifier);
   }
 

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -57,6 +57,19 @@ class Peripheral extends NobleEventEmitter {
     });
   }
 
+  pair (callback) {
+    if (callback) {
+      this.onceExclusive('pair', error => callback(error));
+    }
+    this._noble.pair(this.id);
+  }
+
+  async pairAsync () {
+    return new Promise((resolve, reject) => {
+      this.pair(error => error ? reject(error) : resolve());
+    });
+  }
+
   cancelConnect (options) {
     if (this.state === 'connecting') {
       this.emit('connect', new Error('connection canceled!'));

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -420,11 +420,12 @@ bool BLEManager::Pair(const std::string& uuid)
     // ceremony without a UI prompt. The actual kind the device requests is
     // logged so we can diagnose failures.
     //
-    // The PairingRequested handler must Accept() or Reject() the args exactly
-    // once, otherwise the ceremony hangs until timeout. We auto-Accept only
-    // ConfirmOnly and reject every other kind (DisplayPin / ProvidePassword /
-    // ConfirmPinMatch etc.) since we have no way to surface a UI prompt from
-    // this library.
+    // The PairingRequested handler must Accept() the args exactly once for
+    // ConfirmOnly; for any other kind (DisplayPin / ProvidePassword /
+    // ConfirmPinMatch etc.) we simply return without Accept(), which Windows
+    // treats as a rejection and the PairAsync completes with the appropriate
+    // failure status (RejectedByHandler / AuthenticationNotAllowed). We have
+    // no UI to surface a PIN or password prompt from this library.
     auto custom = pairing.Custom();
     auto token = custom.PairingRequested(
         [](winrt::Windows::Devices::Enumeration::DeviceInformationCustomPairing const&,
@@ -435,11 +436,8 @@ bool BLEManager::Pair(const std::string& uuid)
             {
                 args.Accept();
             }
-            else
-            {
-                LOGE("rejecting pairing: unsupported kind %d", static_cast<int>(kind));
-                args.Reject();
-            }
+            // Any other kind: do not call Accept() — Windows treats the
+            // handler returning as a rejection.
         });
 
     auto completed = bind2(this, &BLEManager::OnPaired, uuid, token, custom);

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -413,8 +413,14 @@ bool BLEManager::Pair(const std::string& uuid)
     // Use custom pairing so we can auto-accept the ConfirmOnly (Just Works)
     // ceremony without a UI prompt. The actual kind the device requests is
     // logged so we can diagnose failures.
+    //
+    // The PairingRequested handler must Accept() or Reject() the args exactly
+    // once, otherwise the ceremony hangs until timeout. We auto-Accept only
+    // ConfirmOnly and reject every other kind (DisplayPin / ProvidePassword /
+    // ConfirmPinMatch etc.) since we have no way to surface a UI prompt from
+    // this library.
     auto custom = pairing.Custom();
-    custom.PairingRequested(
+    auto token = custom.PairingRequested(
         [](winrt::Windows::Devices::Enumeration::DeviceInformationCustomPairing const&,
            winrt::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs const& args) {
             auto kind = args.PairingKind();
@@ -423,9 +429,14 @@ bool BLEManager::Pair(const std::string& uuid)
             {
                 args.Accept();
             }
+            else
+            {
+                LOGE("rejecting pairing: unsupported kind %d", static_cast<int>(kind));
+                args.Reject();
+            }
         });
 
-    auto completed = bind2(this, &BLEManager::OnPaired, uuid);
+    auto completed = bind2(this, &BLEManager::OnPaired, uuid, token, custom);
     custom.PairAsync(DevicePairingKinds::ConfirmOnly, DevicePairingProtectionLevel::Encryption)
         .Completed(completed);
     return true;
@@ -465,8 +476,15 @@ std::string pairingResultStatusToString(DevicePairingResultStatus status)
 }
 
 void BLEManager::OnPaired(IAsyncOperation<DevicePairingResult> asyncOp, AsyncStatus status,
-                          const std::string uuid)
+                          const std::string uuid,
+                          winrt::event_token token,
+                          winrt::Windows::Devices::Enumeration::DeviceInformationCustomPairing custom)
 {
+    // Revoke the PairingRequested handler now that pairing has settled; without
+    // this, a stray callback (e.g. if the device re-prompts) would call Accept/
+    // Reject on already-resolved args and could log confusing messages.
+    custom.PairingRequested(token);
+
     if (status != AsyncStatus::Completed)
     {
         mEmit.Paired(uuid, false, "pairing operation " + asyncStatusToString(status));

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -6,8 +6,13 @@
 #include <winrt/Windows.Security.Cryptography.h>
 #include <winrt/Windows.Devices.Bluetooth.h>
 #include <winrt/Windows.Devices.Bluetooth.GenericAttributeProfile.h>
+#include <winrt/Windows.Devices.Enumeration.h>
 
 
+using winrt::Windows::Devices::Enumeration::DeviceInformationPairing;
+using winrt::Windows::Devices::Enumeration::DevicePairingProtectionLevel;
+using winrt::Windows::Devices::Enumeration::DevicePairingResult;
+using winrt::Windows::Devices::Enumeration::DevicePairingResultStatus;
 using winrt::Windows::Devices::Bluetooth::BluetoothCacheMode;
 using winrt::Windows::Devices::Bluetooth::BluetoothConnectionStatus;
 using winrt::Windows::Devices::Bluetooth::BluetoothLEDevice;
@@ -382,6 +387,105 @@ void BLEManager::OnMaxPduSizeChanged(GattSession session, winrt::Windows::Founda
     // Update MTU value when it changes
     int mtu = session.MaxPduSize();
     mEmit.MTU(uuid, mtu);
+}
+
+bool BLEManager::Pair(const std::string& uuid)
+{
+    using winrt::Windows::Devices::Enumeration::DevicePairingKinds;
+
+    IFDEVICE(device, uuid);
+
+    auto pairing = device.DeviceInformation().Pairing();
+
+    // Already bonded — report success immediately.
+    if (pairing.IsPaired())
+    {
+        mEmit.Paired(uuid, true);
+        return true;
+    }
+
+    if (!pairing.CanPair())
+    {
+        mEmit.Paired(uuid, false, "device reports it cannot be paired");
+        return true;
+    }
+
+    // Use custom pairing so we can auto-accept the ConfirmOnly (Just Works)
+    // ceremony without a UI prompt. The actual kind the device requests is
+    // logged so we can diagnose failures.
+    auto custom = pairing.Custom();
+    custom.PairingRequested(
+        [](winrt::Windows::Devices::Enumeration::DeviceInformationCustomPairing const&,
+           winrt::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs const& args) {
+            auto kind = args.PairingKind();
+            LOGE("pairing requested, kind=%d", static_cast<int>(kind));
+            if (kind == DevicePairingKinds::ConfirmOnly)
+            {
+                args.Accept();
+            }
+        });
+
+    auto completed = bind2(this, &BLEManager::OnPaired, uuid);
+    custom.PairAsync(DevicePairingKinds::ConfirmOnly, DevicePairingProtectionLevel::Encryption)
+        .Completed(completed);
+    return true;
+}
+
+std::string pairingResultStatusToString(DevicePairingResultStatus status)
+{
+    switch (status)
+    {
+        case DevicePairingResultStatus::Paired: return "Paired";
+        case DevicePairingResultStatus::NotReadyToPair: return "NotReadyToPair";
+        case DevicePairingResultStatus::NotPaired: return "NotPaired";
+        case DevicePairingResultStatus::AlreadyPaired: return "AlreadyPaired";
+        case DevicePairingResultStatus::ConnectionRejected: return "ConnectionRejected";
+        case DevicePairingResultStatus::TooManyConnections: return "TooManyConnections";
+        case DevicePairingResultStatus::HardwareFailure: return "HardwareFailure";
+        case DevicePairingResultStatus::AuthenticationTimeout: return "AuthenticationTimeout";
+        case DevicePairingResultStatus::AuthenticationNotAllowed: return "AuthenticationNotAllowed";
+        case DevicePairingResultStatus::AuthenticationFailure: return "AuthenticationFailure";
+        case DevicePairingResultStatus::NoSupportedProfiles: return "NoSupportedProfiles";
+        case DevicePairingResultStatus::ProtectionLevelCouldNotBeMet:
+            return "ProtectionLevelCouldNotBeMet";
+        case DevicePairingResultStatus::AccessDenied: return "AccessDenied";
+        case DevicePairingResultStatus::InvalidCeremonyData: return "InvalidCeremonyData";
+        case DevicePairingResultStatus::PairingCanceled: return "PairingCanceled";
+        case DevicePairingResultStatus::OperationAlreadyInProgress:
+            return "OperationAlreadyInProgress";
+        case DevicePairingResultStatus::RequiredHandlerNotRegistered:
+            return "RequiredHandlerNotRegistered";
+        case DevicePairingResultStatus::RejectedByHandler: return "RejectedByHandler";
+        case DevicePairingResultStatus::RemoteDeviceHasAssociation:
+            return "RemoteDeviceHasAssociation";
+        case DevicePairingResultStatus::Failed: return "Failed";
+        default:
+            return "Unknown(" + std::to_string(static_cast<int>(status)) + ")";
+    }
+}
+
+void BLEManager::OnPaired(IAsyncOperation<DevicePairingResult> asyncOp, AsyncStatus status,
+                          const std::string uuid)
+{
+    if (status != AsyncStatus::Completed)
+    {
+        mEmit.Paired(uuid, false, "pairing operation " + asyncStatusToString(status));
+        return;
+    }
+
+    auto result = asyncOp.GetResults();
+    auto resultStatus = result.Status();
+    LOGE("pairing result status=%s", pairingResultStatusToString(resultStatus).c_str());
+    if (resultStatus == DevicePairingResultStatus::Paired ||
+        resultStatus == DevicePairingResultStatus::AlreadyPaired)
+    {
+        mEmit.Paired(uuid, true);
+    }
+    else
+    {
+        mEmit.Paired(uuid, false,
+                     "pairing failed with status " + pairingResultStatusToString(resultStatus));
+    }
 }
 
 bool BLEManager::Disconnect(const std::string& uuid)

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -393,10 +393,16 @@ bool BLEManager::Pair(const std::string& uuid)
 {
     using winrt::Windows::Devices::Enumeration::DevicePairingKinds;
 
-    IFDEVICE(device, uuid);
+    auto it = mDeviceMap.find(uuid);
+    if (it == mDeviceMap.end() || !it->second.device.has_value())
+    {
+        mEmit.Paired(uuid, false, "device not connected");
+        return true;
+    }
+
+    BluetoothLEDevice& device = *it->second.device;
 
     auto pairing = device.DeviceInformation().Pairing();
-
     // Already bonded — report success immediately.
     if (pairing.IsPaired())
     {

--- a/lib/win/src/ble_manager.h
+++ b/lib/win/src/ble_manager.h
@@ -45,7 +45,7 @@ private:
     void OnScanResult(BluetoothLEAdvertisementWatcher watcher, const BluetoothLEAdvertisementReceivedEventArgs& args);
     void OnScanStopped(BluetoothLEAdvertisementWatcher watcher, const BluetoothLEAdvertisementWatcherStoppedEventArgs& args);
     void OnConnected(IAsyncOperation<BluetoothLEDevice> asyncOp, AsyncStatus status, std::string uuid);
-    void OnPaired(IAsyncOperation<winrt::Windows::Devices::Enumeration::DevicePairingResult> asyncOp, AsyncStatus status, std::string uuid);
+    void OnPaired(IAsyncOperation<winrt::Windows::Devices::Enumeration::DevicePairingResult> asyncOp, AsyncStatus status, std::string uuid, winrt::event_token token, winrt::Windows::Devices::Enumeration::DeviceInformationCustomPairing custom);
     void OnConnectionStatusChanged(BluetoothLEDevice device, winrt::Windows::Foundation::IInspectable inspectable);
     void OnGattSessionCreated(IAsyncOperation<GattSession> asyncOp, AsyncStatus status, std::string uuid);
     void OnMaxPduSizeChanged(GattSession session, winrt::Windows::Foundation::IInspectable object, std::string uuid);

--- a/lib/win/src/ble_manager.h
+++ b/lib/win/src/ble_manager.h
@@ -2,6 +2,7 @@
 
 #include <winrt/Windows.Devices.Bluetooth.Advertisement.h>
 #include <winrt/Windows.Devices.Bluetooth.GenericAttributeProfile.h>
+#include <winrt/Windows.Devices.Enumeration.h>
 
 #include "Emit.h"
 #include "notify_map.h"
@@ -21,6 +22,7 @@ public:
     void Scan(const std::vector<winrt::guid>& serviceUUIDs, bool allowDuplicates);
     void StopScan();
     bool Connect(const std::string& uuid);
+    bool Pair(const std::string& uuid);
     bool Disconnect(const std::string& uuid);
     bool CancelConnect(const std::string& uuid);
     bool UpdateRSSI(const std::string& uuid);
@@ -43,6 +45,7 @@ private:
     void OnScanResult(BluetoothLEAdvertisementWatcher watcher, const BluetoothLEAdvertisementReceivedEventArgs& args);
     void OnScanStopped(BluetoothLEAdvertisementWatcher watcher, const BluetoothLEAdvertisementWatcherStoppedEventArgs& args);
     void OnConnected(IAsyncOperation<BluetoothLEDevice> asyncOp, AsyncStatus status, std::string uuid);
+    void OnPaired(IAsyncOperation<winrt::Windows::Devices::Enumeration::DevicePairingResult> asyncOp, AsyncStatus status, std::string uuid);
     void OnConnectionStatusChanged(BluetoothLEDevice device, winrt::Windows::Foundation::IInspectable inspectable);
     void OnGattSessionCreated(IAsyncOperation<GattSession> asyncOp, AsyncStatus status, std::string uuid);
     void OnMaxPduSizeChanged(GattSession session, winrt::Windows::Foundation::IInspectable object, std::string uuid);

--- a/lib/win/src/noble_winrt.cc
+++ b/lib/win/src/noble_winrt.cc
@@ -101,6 +101,16 @@ Napi::Value NobleWinrt::Connect(const Napi::CallbackInfo& info)
     return info.Env().Undefined();
 }
 
+// pair(deviceUuid)
+Napi::Value NobleWinrt::Pair(const Napi::CallbackInfo& info)
+{
+    CHECK_MANAGER()
+    ARG1(String)
+    auto uuid = info[0].As<Napi::String>().Utf8Value();
+    manager->Pair(uuid);
+    return info.Env().Undefined();
+}
+
 // disconnect(deviceUuid)
 Napi::Value NobleWinrt::Disconnect(const Napi::CallbackInfo& info)
 {
@@ -315,6 +325,7 @@ Napi::Object NobleWinrt::Init(Napi::Env env, Napi::Object exports) {
         NobleWinrt::InstanceMethod("startScanning", &NobleWinrt::Scan),
         NobleWinrt::InstanceMethod("stopScanning", &NobleWinrt::StopScan),
         NobleWinrt::InstanceMethod("connect", &NobleWinrt::Connect),
+        NobleWinrt::InstanceMethod("pair", &NobleWinrt::Pair),
         NobleWinrt::InstanceMethod("disconnect", &NobleWinrt::Disconnect),
         NobleWinrt::InstanceMethod("cancelConnect", &NobleWinrt::CancelConnect),
         NobleWinrt::InstanceMethod("updateRssi", &NobleWinrt::UpdateRSSI),

--- a/lib/win/src/noble_winrt.h
+++ b/lib/win/src/noble_winrt.h
@@ -13,6 +13,7 @@ public:
     Napi::Value Scan(const Napi::CallbackInfo&);
     Napi::Value StopScan(const Napi::CallbackInfo&);
     Napi::Value Connect(const Napi::CallbackInfo&);
+    Napi::Value Pair(const Napi::CallbackInfo&);
     Napi::Value Disconnect(const Napi::CallbackInfo&);
     Napi::Value CancelConnect(const Napi::CallbackInfo&);
     Napi::Value UpdateRSSI(const Napi::CallbackInfo&);


### PR DESCRIPTION
Expose pair/pairAsync on noble's peripheral; emits a pair event Windows path goes through DeviceInformation.Custom for custom pairing and auto-accepts the ConfirmOnly (Just Works) ceremony Already-paired devices return success immediately; CanPair=false surfaces an error Convert DevicePairingResultStatus to a readable string for easier failure diagnosis