### PR TITLE
chore(deps): bump Bluetooth HCI socket to 2.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -47,7 +47,7 @@
         "node": ">=14"
       },
       "optionalDependencies": {
-        "@stoprocent/bluetooth-hci-socket": "^2.2.8"
+        "@stoprocent/bluetooth-hci-socket": "^2.3.0"
       },
       "peerDependencies": {
         "dbus-next": "^0.10.0"
@@ -3086,9 +3086,9 @@
       "license": "(Unlicense OR Apache-2.0)"
     },
     "node_modules/@stoprocent/bluetooth-hci-socket": {
-      "version": "2.2.8",
-      "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.2.8.tgz",
-      "integrity": "sha512-Nbnj3ZoDMHCGU9p4t+tZbPJp7tbyCaPF4o1qcpegUZKauQi12wqLjYv3GPZmNSpgM/5kmtEq9PpfxCM3w6AT7g==",
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@stoprocent/bluetooth-hci-socket/-/bluetooth-hci-socket-2.3.0.tgz",
+      "integrity": "sha512-xTigfmWCBqNJyPibOCS8F4dTt0LdE5zHAlpOc919ladh1Q+PjQgSGMQZoXxpK9CzZgZCmPF5f90jC0IkogwQEg==",
       "hasInstallScript": true,
       "license": "MIT",
       "optional": true,

--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "patch-package": "^8.0.0"
   },
   "optionalDependencies": {
-    "@stoprocent/bluetooth-hci-socket": "^2.2.8"
+    "@stoprocent/bluetooth-hci-socket": "^2.3.0"
   },
   "peerDependencies": {
     "dbus-next": "^0.10.0"


### PR DESCRIPTION
## What changed

- bump the optional `@stoprocent/bluetooth-hci-socket` dependency range to `^2.3.0`
- refresh the lockfile to resolve HCI Socket 2.3.0

## Why

Consume the latest released HCI Socket, including ASUS USB-BT500 support while retaining the prior Linux connection fixes and prebuild coverage.

## Validation

- `npm ci`
- `npm run lint`
- `npm test -- --runInBand` (19 suites passed; 697 passed, 1 skipped)
- `npm ls @stoprocent/bluetooth-hci-socket --json` (2.3.0)