### PR TITLE
fix(hci): initialize ACL buffers in user channel mode

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -392,7 +392,7 @@ NobleBindings.prototype.onLeConnComplete = function (
     );
     const connectionParams = matchesPendingConnection ? currentConn.params : {};
     const gatt = new Gatt(address, aclStream, connectionParams && connectionParams.mtu);
-    const signaling = new Signaling(handle, aclStream);
+    const signaling = new Signaling(handle, aclStream, this._hci.isUserChannel());
 
     this._gatts[uuid] = this._gatts[handle] = gatt;
     this._signalings[uuid] = this._signalings[handle] = signaling;

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -91,6 +91,9 @@ const LE_CREATE_EXTENDED_CONN_CMD =
 const LE_CONN_UPDATE_CMD = OCF_LE_CONN_UPDATE | (OGF_LE_CTL << 10);
 const LE_CANCEL_CONN_CMD = OCF_LE_CANCEL_CONN | (OGF_LE_CTL << 10);
 const LE_START_ENCRYPTION_CMD = OCF_LE_START_ENCRYPTION | (OGF_LE_CTL << 10);
+
+// Core Spec Vol 6 Part B 2.4: every LE controller supports at least a 27 octet payload
+const LE_MIN_ACL_LENGTH = 27;
 const HCI_OE_USER_ENDED_CONNECTION = 0x13;
 
 const STATUS_MAPPER = require('./hci-status');
@@ -156,6 +159,10 @@ Object.setPrototypeOf(Hci.prototype, EventEmitter.prototype);
 
 Hci.STATUS_MAPPER = STATUS_MAPPER;
 
+Hci.prototype.isUserChannel = function () {
+  return this._userChannel;
+};
+
 Hci.prototype.init = function (options) {
   this._socket.on('data', this.onSocketData.bind(this));
   this._socket.on('error', this.onSocketError.bind(this));
@@ -174,11 +181,16 @@ Hci.prototype.init = function (options) {
 
     // Start and reset (common to both paths)
     this._socket.start();
-    this.reset();
 
-    // Set started flag and poll only for non-userChannel
+    if (this._userChannel) {
+      // No kernel command flow control on the user channel: nothing serialises this behind HCI_Reset
+      this.once('reset', () => this.readLeSupportedFeatures());
+    }
+
+    this.reset();
+    this._isStarted = true;
+
     if (!this._userChannel) {
-      this._isStarted = true;
       this.pollIsDevUp();
     }
   } catch (error) {
@@ -207,7 +219,7 @@ Hci.prototype.pollIsDevUp = function () {
 
     this._isDevUp = isDevUp;
   }
-  if (this._isStarted && this._devUpPollTimer === null) {
+  if (this._isStarted && !this._userChannel && this._devUpPollTimer === null) {
     this._devUpPollTimer = setTimeout(() => {
       this._devUpPollTimer = null;
       this.pollIsDevUp();
@@ -990,12 +1002,16 @@ Hci.prototype.onSocketError = function (error) {
 Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
   if (cmd === RESET_CMD) {
     this.afterReset();
-  } else if (cmd === LE_READ_LOCAL_SUPPORTED_FEATURES && status === 0) {
-    if (!this._extendedModeConfigured) {
-      // Auto-detect from the LE Extended Advertising feature bit (12).
-      this._isExtended = (result[1] & (1 << 4)) !== 0;
+  } else if (cmd === LE_READ_LOCAL_SUPPORTED_FEATURES) {
+    if (status === 0) {
+      if (!this._extendedModeConfigured) {
+        // Auto-detect from the LE Extended Advertising feature bit (12).
+        this._isExtended = (result[1] & (1 << 4)) !== 0;
+      }
+      this.emit('leFeatures', result);
+    } else {
+      debug(`le read local supported features failed - status: ${status}`);
     }
-    this.emit('leFeatures', result);
 
     if (this._isExtended) {
       this.setCodedPhySupport();
@@ -1096,26 +1112,29 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
 
     this.emit('rssiRead', handle, rssi);
   } else if (cmd === LE_READ_BUFFER_SIZE_CMD) {
-    if (status === 0) {
-      const aclLength = result.readUInt16LE(0);
-      const aclNum = result.readUInt8(2);
+    const aclLength = status === 0 ? result.readUInt16LE(0) : 0;
+    const aclNum = status === 0 ? result.readUInt8(2) : 0;
 
-      /* Spec Vol 4 Part E.7.8
-      /* No dedicated LE Buffer exists. Use the HCI_Read_Buffer_Size command. */
-      if (aclLength === 0 || aclNum === 0) {
-        debug('using br/edr buffer size');
-        this.readBufferSize();
-      } else {
-        debug(`le buffer size: length = ${aclLength}, num = ${aclNum}`);
-        this.setAclBuffers(aclLength, aclNum);
-      }
+    /* Spec Vol 4 Part E.7.8
+    /* No dedicated LE Buffer exists. Use the HCI_Read_Buffer_Size command. */
+    if (aclLength === 0 || aclNum === 0) {
+      debug(`using br/edr buffer size - le status: ${status}`);
+      this.readBufferSize();
+    } else {
+      debug(`le buffer size: length = ${aclLength}, num = ${aclNum}`);
+      this.setAclBuffers(aclLength, aclNum);
     }
   } else if (cmd === READ_BUFFER_SIZE_CMD) {
-    const aclLength = result.readUInt16LE(0);
-    const aclNum = result.readUInt16LE(3);
+    const aclLength = status === 0 ? result.readUInt16LE(0) : 0;
+    const aclNum = status === 0 ? result.readUInt16LE(3) : 0;
 
-    debug(`buffer size: length = ${aclLength}, num = ${aclNum}`);
-    this.setAclBuffers(aclLength, aclNum);
+    if (aclLength === 0 || aclNum === 0) {
+      debug(`no usable buffer size reported - falling back to le minimum - status: ${status}`);
+      this.setAclBuffers(LE_MIN_ACL_LENGTH, 1);
+    } else {
+      debug(`buffer size: length = ${aclLength}, num = ${aclNum}`);
+      this.setAclBuffers(aclLength, aclNum);
+    }
   }
 };
 

--- a/lib/hci-socket/signaling.js
+++ b/lib/hci-socket/signaling.js
@@ -8,9 +8,10 @@ const CONNECTION_PARAMETER_UPDATE_RESPONSE = 0x13;
 
 const SIGNALING_CID = 0x0005;
 
-const Signaling = function (handle, aclStream) {
+const Signaling = function (handle, aclStream, userChannel) {
   this._handle = handle;
   this._aclStream = aclStream;
+  this._userChannel = userChannel;
 
   this.onAclStreamDataBinded = this.onAclStreamData.bind(this);
   this.onAclStreamEndBinded = this.onAclStreamEnd.bind(this);
@@ -58,7 +59,7 @@ Signaling.prototype.processConnectionParameterUpdateRequest = function (identifi
   debug('\t\tlatency = ', latency);
   debug('\t\tsupervision timeout = ', supervisionTimeout);
 
-  if (os.platform() !== 'linux' || process.env.HCI_CHANNEL_USER) {
+  if (os.platform() !== 'linux' || this._userChannel) {
     const response = Buffer.alloc(6);
 
     response.writeUInt8(CONNECTION_PARAMETER_UPDATE_RESPONSE, 0); // code

--- a/test/lib/hci-socket/bindings.test.js
+++ b/test/lib/hci-socket/bindings.test.js
@@ -43,6 +43,7 @@ jest.mock('../../../lib/hci-socket/hci', () => {
   hciMock.prototype.init = jest.fn();
   hciMock.prototype.setAddress = jest.fn().mockResolvedValue(null);
   hciMock.prototype.reset = jest.fn().mockResolvedValue(null);
+  hciMock.prototype.isUserChannel = jest.fn();
   
   // Add STATUS_MAPPER to the constructor
   hciMock.STATUS_MAPPER = { 1: 'custom mapper' };
@@ -93,7 +94,9 @@ describe('hci-socket bindings', () => {
     
     // Reset all mock state
     jest.clearAllMocks();
-    
+    // clearAllMocks() doesn't clear mockReturnValue - reassert so it can't leak across tests.
+    Hci.prototype.isUserChannel.mockReturnValue(false);
+
     // Mock timing functions
     jest.useFakeTimers();
     
@@ -249,6 +252,21 @@ describe('hci-socket bindings', () => {
       }));
       should(bindings._connectionQueue).be.empty();
       expect(bindings._hci.createLeConn).not.toHaveBeenCalled();
+    });
+
+    it('does not overlap a user-channel initialization reset with a connect reset', () => {
+      bindings._state = null;
+      bindings._hci.isUserChannel.mockReturnValue(true);
+      bindings._hci.reset = jest.fn();
+      bindings._hci.createLeConn = jest.fn();
+
+      // Model the reset already issued by Hci.init() before poweredOn.
+      bindings._hci.reset();
+      bindings.connect('112233445566');
+
+      expect(bindings._hci.reset).toHaveBeenCalledTimes(1);
+      expect(bindings._hci.createLeConn).not.toHaveBeenCalled();
+      should(bindings._connectionQueue).be.empty();
     });
 
     it('coalesces duplicate requests for the same peripheral', () => {
@@ -992,6 +1010,7 @@ describe('hci-socket bindings', () => {
       expect(AclStream).toHaveBeenCalledTimes(1);
       expect(Gatt).toHaveBeenCalledTimes(1);
       expect(Signaling).toHaveBeenCalledTimes(1);
+      expect(Signaling).toHaveBeenCalledWith(handle, expect.anything(), false);
 
       expect(Gatt.onMock).toHaveBeenCalledTimes(17);
       expect(Gatt.onMock).toHaveBeenCalledWith(expect.any(String), expect.any(Function));
@@ -1020,6 +1039,21 @@ describe('hci-socket bindings', () => {
       expect(connectCallback).toHaveBeenCalledWith('addresssplitbyseparator', null);
 
       should(bindings._pendingConnectionUuid).equal(null);
+    });
+
+    it('threads the hci userChannel flag into Signaling', () => {
+      const status = 0;
+      const handle = 'handle';
+      const role = 0;
+      const addressType = 'addressType';
+      const address = 'address:split:by:separator';
+
+      bindings._hci.isUserChannel.mockReturnValue(true);
+      bindings.onLeConnComplete(status, handle, role, addressType, address);
+
+      jest.advanceTimersByTime(0);
+
+      expect(Signaling).toHaveBeenCalledWith(handle, expect.anything(), true);
     });
 
     it('with invalid status on master node', () => {

--- a/test/lib/hci-socket/hci.test.js
+++ b/test/lib/hci-socket/hci.test.js
@@ -136,6 +136,7 @@ describe('hci-socket hci', () => {
 
     it('should bindRaw', () => {
       hci.pollIsDevUp = sinon.spy();
+      hci.readLeSupportedFeatures = sinon.spy();
 
       hci._userChannel = undefined;
       hci._bound = false;
@@ -150,8 +151,10 @@ describe('hci-socket hci', () => {
       assert.calledOnceWithExactly(hci._socket.start);
 
       assert.calledOnceWithExactly(hci.pollIsDevUp);
+      assert.notCalled(hci.readLeSupportedFeatures);
 
       should(hci._bound).be.true();
+      should(hci._isStarted).be.true();
     });
 
     it('should not bindRaw', () => {
@@ -172,6 +175,27 @@ describe('hci-socket hci', () => {
       assert.calledOnceWithExactly(hci.pollIsDevUp);
 
       should(hci._bound).be.true();
+    });
+
+    it('should defer LE Read Local Supported Features until reset completes, and skip pollIsDevUp, for user channel', () => {
+      hci.pollIsDevUp = sinon.spy();
+      hci.readLeSupportedFeatures = sinon.spy();
+      hci.setSocketFilter = sinon.spy();
+
+      hci._userChannel = true;
+      hci.init();
+
+      assert.calledOnceWithExactly(hci._socket.bindUser, deviceId, undefined);
+      assert.calledOnceWithExactly(hci._socket.start);
+
+      assert.notCalled(hci.readLeSupportedFeatures);
+      assert.notCalled(hci.pollIsDevUp);
+      assert.notCalled(hci.setSocketFilter);
+      should(hci._isStarted).be.true();
+
+      hci.emit('reset');
+
+      assert.calledOnceWithExactly(hci.readLeSupportedFeatures);
     });
   });
 
@@ -363,6 +387,17 @@ describe('hci-socket hci', () => {
       hci.pollIsDevUp();
 
       should(sinon.clock.countTimers()).equal(1);
+    });
+
+    it('should not reschedule itself for user channel', () => {
+      hci._userChannel = true;
+      hci._isStarted = true;
+      hci._socket.isDevUp.returns(true);
+      hci._isDevUp = true;
+
+      hci.pollIsDevUp();
+
+      should(sinon.clock.countTimers()).equal(0);
     });
   });
 
@@ -738,6 +773,98 @@ describe('hci-socket hci', () => {
     should(hci._aclConnections.size).equal(0);
   });
 
+  it('should resolve getAclBuffers after LE_READ_BUFFER_SIZE_CMD command complete', async () => {
+    const aclBuffersPromise = hci.getAclBuffers();
+
+    hci.processCmdCompleteEvent(8194, 0, Buffer.from([0x10, 0x00, 5]));
+
+    should(await aclBuffersPromise).deepEqual({ length: 0x10, num: 5 });
+  });
+
+  it('should resolve getAclBuffers when LE Read Buffer Size reports zero and BR/EDR succeeds', async () => {
+    const LE_READ_BUFFER_SIZE_CMD = 8194;
+    const READ_BUFFER_SIZE_CMD = 4101;
+    const aclBuffersPromise = hci.getAclBuffers();
+
+    hci.processCmdCompleteEvent(LE_READ_BUFFER_SIZE_CMD, 0, Buffer.from([0, 0, 0]));
+    hci.processCmdCompleteEvent(READ_BUFFER_SIZE_CMD, 0, Buffer.from([0x40, 0x00, 3, 0x0a, 0x00]));
+
+    should(await aclBuffersPromise).deepEqual({ length: 0x40, num: 10 });
+  });
+
+  it('should resolve getAclBuffers with the LE minimum and still write ACL data when both buffer-size commands fail', async () => {
+    const LE_READ_BUFFER_SIZE_CMD = 8194;
+    const READ_BUFFER_SIZE_CMD = 4101;
+    const aclBuffersPromise = hci.getAclBuffers();
+
+    hci.processCmdCompleteEvent(LE_READ_BUFFER_SIZE_CMD, 0x0c, Buffer.from([]));
+    hci.processCmdCompleteEvent(READ_BUFFER_SIZE_CMD, 0x0c, Buffer.from([]));
+
+    const timedOut = Symbol('timedOut');
+    let timer;
+    const timeout = new Promise((resolve) => {
+      timer = setTimeout(() => resolve(timedOut), 300);
+    });
+    const aclBuffers = await Promise.race([aclBuffersPromise, timeout]);
+    clearTimeout(timer);
+
+    should(aclBuffers).deepEqual({ length: 27, num: 1 });
+
+    const handle = 0x1234;
+    hci._aclConnections.set(4660, { pending: 0 });
+
+    const writePromise = hci.writeAclDataPkt(handle, 345, Buffer.from([1, 2, 3]));
+    let writeTimer;
+    const writeTimeout = new Promise((resolve) => {
+      writeTimer = setTimeout(() => resolve(timedOut), 300);
+    });
+    const outcome = await Promise.race([writePromise.then(() => 'resolved'), writeTimeout]);
+    clearTimeout(writeTimer);
+
+    should(outcome).equal('resolved');
+    should(hci._socket.write.args.some(([buf]) => buf[0] === 0x02 /* HCI_ACLDATA_PKT */)).be.true();
+  });
+
+  it('should write ACL data after init drives the LE buffer size chain in user channel mode (issue #109)', async () => {
+    const buildCmdCompleteEvent = (cmd, status, result) => {
+      const header = Buffer.from([0x04 /* HCI_EVENT_PKT */, 0x0e /* EVT_CMD_COMPLETE */, 3 + result.length, 1]);
+      const cmdBuf = Buffer.alloc(2);
+      cmdBuf.writeUInt16LE(cmd, 0);
+      return Buffer.concat([header, cmdBuf, Buffer.from([status]), result]);
+    };
+    const wroteCmd = (cmd) => hci._socket.write.args.some(([buf]) => buf.readUInt16LE(1) === cmd);
+    const RESET_CMD = 3075;
+    const LE_READ_LOCAL_SUPPORTED_FEATURES = 8195;
+    const LE_READ_BUFFER_SIZE_CMD = 8194;
+
+    hci._userChannel = true;
+    hci.init();
+
+    should(wroteCmd(LE_READ_LOCAL_SUPPORTED_FEATURES)).be.false();
+    hci.onSocketData(buildCmdCompleteEvent(RESET_CMD, 0, Buffer.alloc(0)));
+
+    should(wroteCmd(LE_READ_LOCAL_SUPPORTED_FEATURES)).be.true();
+    hci.onSocketData(buildCmdCompleteEvent(LE_READ_LOCAL_SUPPORTED_FEATURES, 0, Buffer.alloc(8)));
+
+    should(wroteCmd(LE_READ_BUFFER_SIZE_CMD)).be.true();
+    hci.onSocketData(buildCmdCompleteEvent(LE_READ_BUFFER_SIZE_CMD, 0, Buffer.from([0x10, 0x00, 5])));
+
+    const handle = 0x1234;
+    hci._aclConnections.set(handle, { pending: 0 });
+
+    const writePromise = hci.writeAclDataPkt(handle, 345, Buffer.from([5, 6, 7]));
+    const timedOut = Symbol('timedOut');
+    let timer;
+    const timeout = new Promise((resolve) => {
+      timer = setTimeout(() => resolve(timedOut), 300);
+    });
+    const outcome = await Promise.race([writePromise.then(() => 'resolved'), timeout]);
+    clearTimeout(timer);
+
+    should(outcome).equal('resolved');
+    should(hci._socket.write.args.some(([buf]) => buf[0] === 0x02 /* HCI_ACLDATA_PKT */)).be.true();
+  });
+
   describe('flushAcl', () => {
     it('should not write flush on no pending connections', () => {
       const queue = [
@@ -821,6 +948,49 @@ describe('hci-socket hci', () => {
       assert.calledWithExactly(hci._socket.write, Buffer.from([0x02]));
 
       should(hci._aclQueue).be.empty();
+      should(hci._aclConnections.get(4660).pending).equal(5);
+      should(hci._aclConnections.get(4661).pending).equal(3);
+    });
+
+    it('should skip a queued packet whose connection is gone, without throwing, and keep flushing the rest', async () => {
+      const queue = [
+        { handle: 4660, packet: Buffer.from([0x02, 0xaa]) },
+        { handle: 4661, packet: Buffer.from([0x02, 0xbb]) }
+      ];
+      hci._aclQueue = [...queue];
+      hci._aclConnections.set(4661, { pending: 0 });
+      hci._aclBuffers = { num: 12 };
+
+      await hci.flushAcl();
+
+      assert.calledOnceWithExactly(hci._socket.write, Buffer.from([0x02, 0xbb]));
+      should(hci._aclQueue).be.empty();
+      should(hci._aclConnections.get(4661).pending).equal(1);
+    });
+
+    it('should not throw when a disconnect completes for the handle while writeAclDataPkt is awaiting acl buffers', async () => {
+      const handle = 0x1234;
+      hci._aclConnections.set(4660, { pending: 0 });
+
+      const flushAclPromises = [];
+      const originalFlushAcl = hci.flushAcl.bind(hci);
+      hci.flushAcl = (...args) => {
+        const promise = originalFlushAcl(...args);
+        flushAclPromises.push(promise);
+        return promise;
+      };
+
+      const writePromise = hci.writeAclDataPkt(handle, 345, Buffer.from([1, 2, 3]));
+
+      // EVT_DISCONN_COMPLETE for the same handle, landing before writeAclDataPkt resumes from its acl-buffers await
+      hci.onSocketData(Buffer.from([0x04, 0x05, 0, 0, 0x34, 0x12, 0x13]));
+
+      hci.setAclBuffers(20, 5);
+
+      await writePromise;
+      await Promise.all(flushAclPromises);
+
+      should(hci._aclConnections.has(4660)).be.false();
     });
 
     it('should skip a queued packet whose connection is gone, without throwing, and keep draining the rest', async () => {
@@ -1341,26 +1511,41 @@ describe('hci-socket hci', () => {
       jest.clearAllMocks();
     });
     
-    test('should not process on error status', () => {
+    test('should still complete the init chain on error status, but skip leFeatures and isExtended', () => {
       const cmd = 8195;
       const status = 1;
       const result = Buffer.from([0x00, 0x00, 0x00, 0x00]);
-  
+      const leFeaturesCallback = jest.fn();
+      hci.on('leFeatures', leFeaturesCallback);
+
       hci.processCmdCompleteEvent(cmd, status, result);
-  
-      // Verify no methods were called
+
       expect(hci.setCodedPhySupport).not.toHaveBeenCalled();
-      expect(hci.setEventMask).not.toHaveBeenCalled();
-      expect(hci.setLeEventMask).not.toHaveBeenCalled();
-      expect(hci.readLocalVersion).not.toHaveBeenCalled();
-      expect(hci.writeLeHostSupported).not.toHaveBeenCalled();
-      expect(hci.readLeHostSupported).not.toHaveBeenCalled();
-      expect(hci.readLeBufferSize).not.toHaveBeenCalled();
-      expect(hci.readBdAddr).not.toHaveBeenCalled();
-  
+      expect(leFeaturesCallback).not.toHaveBeenCalled();
       expect(hci._isExtended).toBe(false);
+
+      // The rest of the chain must still run, or ACL writes hang forever (issue #109).
+      expect(hci.setEventMask).toHaveBeenCalled();
+      expect(hci.setLeEventMask).toHaveBeenCalled();
+      expect(hci.readLocalVersion).toHaveBeenCalled();
+      expect(hci.writeLeHostSupported).toHaveBeenCalled();
+      expect(hci.readLeHostSupported).toHaveBeenCalled();
+      expect(hci.readLeBufferSize).toHaveBeenCalled();
+      expect(hci.readBdAddr).toHaveBeenCalled();
     });
-  
+
+    test('should resolve getAclBuffers after a failed status once LE Read Buffer Size completes', async () => {
+      const aclBuffersPromise = hci.getAclBuffers();
+
+      hci.processCmdCompleteEvent(8195, 0x0c, Buffer.from([0x00, 0x00, 0x00, 0x00]));
+
+      expect(hci.readLeBufferSize).toHaveBeenCalled();
+
+      hci.processCmdCompleteEvent(8194, 0, Buffer.from([0x10, 0x00, 5]));
+
+      should(await aclBuffersPromise).deepEqual({ length: 0x10, num: 5 });
+    });
+
     test('should process without extended features', () => {
       const cmd = 8195;
       const status = 0;
@@ -1436,7 +1621,7 @@ describe('hci-socket hci', () => {
       hci.readBufferSize = sinon.spy();
       hci.setCodedPhySupport = sinon.spy();
 
-      hci._aclBuffers = aclBuffers;
+      hci._aclBuffers = { ...aclBuffers };
 
       rssiReadCallback = sinon.spy();
       leScanEnableSetCallback = sinon.spy();
@@ -1939,36 +2124,6 @@ describe('hci-socket hci', () => {
       should(hci._isExtended).equal(false);
     });
 
-    it('should do nothing - LE_READ_BUFFER_SIZE_CMD', () => {
-      const cmd = 8194;
-      const status = 0;
-      const result = Buffer.from([1, 0, 2]);
-
-      hci.processCmdCompleteEvent(cmd, status, result);
-
-      // called
-
-      // not called
-      assert.notCalled(hci.readBufferSize);
-      assert.notCalled(rssiReadCallback);
-      assert.notCalled(addressChangeCallback);
-      assert.notCalled(hci.setEventMask);
-      assert.notCalled(hci.setLeEventMask);
-      assert.notCalled(hci.readLocalVersion);
-      assert.notCalled(hci.readBdAddr);
-      assert.notCalled(hci.setScanEnabled);
-      assert.notCalled(hci.setScanParameters);
-      assert.notCalled(hci.setCodedPhySupport);
-      assert.notCalled(leScanEnableSetCallback);
-      assert.notCalled(stateChangeCallback);
-      assert.notCalled(leScanParametersSetCallback);
-      assert.notCalled(readLocalVersionCallback);
-
-      // hci checks
-      should(hci._aclBuffers).deepEqual(aclBuffers);
-      should(hci._isExtended).equal(false);
-    });
-
     it('should do nothing - READ_BUFFER_SIZE_CMD', () => {
       const cmd = 4101;
       const status = 0;
@@ -2000,6 +2155,47 @@ describe('hci-socket hci', () => {
         num: 2
       });
       should(hci._isExtended).equal(false);
+    });
+
+    it('should not throw and delegate to READ_BUFFER_SIZE - LE_READ_BUFFER_SIZE_CMD with error status', () => {
+      const cmd = 8194;
+      const status = 0x0c;
+      const result = Buffer.from([]);
+
+      should(() => hci.processCmdCompleteEvent(cmd, status, result)).not.throw();
+
+      assert.calledOnceWithExactly(hci.readBufferSize);
+      should(hci._aclBuffers).deepEqual(aclBuffers);
+    });
+
+    it('should not throw and fall back to the LE minimum - READ_BUFFER_SIZE_CMD with error status', () => {
+      const cmd = 4101;
+      const status = 0x0c;
+      const result = Buffer.from([]);
+
+      should(() => hci.processCmdCompleteEvent(cmd, status, result)).not.throw();
+
+      should(hci._aclBuffers).deepEqual({ length: 27, num: 1 });
+    });
+
+    it('should fall back to the LE minimum - READ_BUFFER_SIZE_CMD with zero acl length', () => {
+      const cmd = 4101;
+      const status = 0;
+      const result = Buffer.from([0, 0, 3, 2, 0]);
+
+      hci.processCmdCompleteEvent(cmd, status, result);
+
+      should(hci._aclBuffers).deepEqual({ length: 27, num: 1 });
+    });
+
+    it('should fall back to the LE minimum - READ_BUFFER_SIZE_CMD with zero acl num', () => {
+      const cmd = 4101;
+      const status = 0;
+      const result = Buffer.from([1, 0, 0, 0, 0]);
+
+      hci.processCmdCompleteEvent(cmd, status, result);
+
+      should(hci._aclBuffers).deepEqual({ length: 27, num: 1 });
     });
 
     it('should do nothing - ??', () => {

--- a/test/lib/hci-socket/signaling.test.js
+++ b/test/lib/hci-socket/signaling.test.js
@@ -87,5 +87,40 @@ describe('hci-socket signaling', () => {
       expect(callback).toHaveBeenCalledWith(handle, 1.25, 2.5, 3, 40);
       expect(aclStream.write).toHaveBeenCalledWith(5, Buffer.from([0x13, 0x01, 0x02, 0x00, 0x00, 0x00]));
     });
+
+    test('should write on linux when userChannel option is true', () => {
+      os.platform.mockReturnValue('linux');
+      const userChannelSignaling = new Signaling(handle, aclStream, true);
+      const callback = jest.fn();
+
+      userChannelSignaling.on('connectionParameterUpdateRequest', callback);
+      userChannelSignaling.processConnectionParameterUpdateRequest(1, Buffer.from([1, 0, 2, 0, 3, 0, 4, 0]));
+
+      expect(callback).toHaveBeenCalledWith(handle, 1.25, 2.5, 3, 40);
+      expect(aclStream.write).toHaveBeenCalledWith(5, Buffer.from([0x13, 0x01, 0x02, 0x00, 0x00, 0x00]));
+    });
+
+    test('should not write on linux when userChannel option is false, even if HCI_CHANNEL_USER is set', () => {
+      const originalEnv = process.env.HCI_CHANNEL_USER;
+      process.env.HCI_CHANNEL_USER = '1';
+
+      try {
+        os.platform.mockReturnValue('linux');
+        const nonUserChannelSignaling = new Signaling(handle, aclStream, false);
+        const callback = jest.fn();
+
+        nonUserChannelSignaling.on('connectionParameterUpdateRequest', callback);
+        nonUserChannelSignaling.processConnectionParameterUpdateRequest(1, Buffer.from([1, 0, 2, 0, 3, 0, 4, 0]));
+
+        expect(callback).not.toHaveBeenCalled();
+        expect(aclStream.write).not.toHaveBeenCalled();
+      } finally {
+        if (typeof originalEnv === 'undefined') {
+          delete process.env.HCI_CHANNEL_USER;
+        } else {
+          process.env.HCI_CHANNEL_USER = originalEnv;
+        }
+      }
+    });
   });
 });


### PR DESCRIPTION
Fixes #109.

## The bug

In user-channel mode `init()` skipped `pollIsDevUp()`, which is the only caller of `readLeSupportedFeatures()`. That command's completion is what issues `LE Read Buffer Size`, whose completion is what calls `setAclBuffers()` and resolves `getAclBuffers()`. Both ACL write paths await that promise:

```js
Hci.prototype.writeAclDataPkt = async function (handle, cid, data) {
  const l2capLength = 4 /* l2cap header */ + data.length;
  const aclBuffers = await this.getAclBuffers();
```

So on user channel every data write blocked forever. Scanning and connecting worked, and then nothing — no `ATT Exchange MTU Request`, no GATT, no L2CAP response, and no error anywhere.

A `btmon` capture from a real user-channel run (matter-js/matterjs-server#929) shows a connection established and held, the peripheral sending an L2CAP `Connection Parameter Update Request` five seconds later, and noble replying with nothing. `ACL Data TX`, `Exchange MTU`, `Read Buffer Size` and `Local Supported Features` each appear **zero** times in the whole capture. The application sat silent for 179.8 s until its own timeout.

## What this changes

**Start the LE init chain on user channel**, deferred until `HCI_Reset` completes. The raw path can issue it in the same tick because the kernel serialises commands through `hdev->cmd_q` under `cmd_cnt` flow control. `HCI_CHANNEL_USER` has no such layer — noble *is* the host stack — so an unserialised command can be answered `Command Disallowed`. Hence the deferral, and the one comment explaining why the two paths differ.

**Don't run the dev-up poll loop on user channel.** There is no `HCI_UP` flapping to track once the kernel has handed the controller over exclusively. `_isStarted` is now set on both paths, so the `pollIsDevUp` reschedule is gated on `!_userChannel`; the socket `state` listener is registered unconditionally and would otherwise arm a permanent 1 Hz timer.

**Make the buffer-size chain always terminate in a resolution.** This is the part I'd most like a second opinion on. Three independent routes led to the same outcome — a permanently unsettled `getAclBuffers()` and therefore a silent, errorless, unrecoverable stall of all ACL traffic:

1. `readLeSupportedFeatures()` never sent (the reported bug)
2. `LE Read Local Supported Features` returning a non-zero status — the branch was gated `cmd === X && status === 0` with no `else`
3. either buffer-size command failing or reporting zero buffers

Three routes to one failure mode says the defect is the never-settling promise, not each route. The chain now degrades LE → BR/EDR → spec minimum (`27`, guaranteed by Core Spec Vol 6 Part B §2.4), and only `_isExtended` and the `leFeatures` event depend on a successful features read. Degrading to a 27-octet payload is slow but correct, and better than an unrecoverable stall on a controller already misbehaving. Happy to drop that fallback if you'd rather it fail loudly instead.

**Guard both buffer-size branches against absent return parameters.** A non-zero-status Command Complete carries none, so the previous unguarded `result.readUInt16LE(0)` threw a `RangeError` inside the socket `data` listener, uncaught. A zero `aclLength` also drove `writeAclDataPkt`'s fragmentation loop to queue 5-byte fragments until OOM — the LE branch guarded zero, the BR/EDR branch did not. Both newly reachable on user channel because of this change.

**Guard `flushAcl` against a handle that vanished.** `writeAclDataPkt` awaits `getAclBuffers()` *before* queueing, so a disconnect arriving during that suspension deletes the connection and filters the queue, after which the continuation queues a packet for a dead handle and `this._aclConnections.get(handle).pending++` throws. Because `AclStream.write` → `writeAclDataPkt` → `flushAcl()` is unawaited, that was an unhandled rejection, i.e. a process abort on Node ≥ 15. Mirrors the guard the `EVT_NUMBER_OF_COMPLETED_PACKETS` branch already has.

**`Signaling` uses the resolved `userChannel` flag** instead of reading `process.env.HCI_CHANNEL_USER`, so a caller passing `{ userChannel: true }` in code also responds to connection parameter update requests. Threaded via a new `Hci.prototype.isUserChannel()` rather than reaching across the module boundary into `_userChannel`.

## Tests

`npx jest`: 19 suites, 729 passed, 1 skipped, 0 failures (730 total, up from 714). `npm run lint` clean.

Every production hunk was mutation-tested — reverted individually to confirm the tests fail. The two that matter most:

- reverting the init change fails the `issue #109` regression test in ~0.15 s rather than hanging the suite
- reverting the buffer-size fallback fails the end-to-end test with `Symbol(timedOut)`, because `getAclBuffers()` never settles

## Deliberately not in this PR

- **#110** — the `'reset'` event has no correlation between a request and the completion that satisfies it. This PR adds a second `once('reset', ...)` subscriber, which is what makes that latent flaw reachable. Fixing it properly means giving `reset()` a promise-based FIFO, which is a design change, not a bug fix.
- **`_isExtended` is now auto-detected on user channel**, overriding a caller's explicit `extended` option. This matches raw-mode behaviour, but it is an undocumented behaviour change for existing `HCI_CHANNEL_USER` users on BT5 controllers, who will silently switch to extended scan commands. Say the word if you want the option to win instead, or a README note.
- **`READ_LOCAL_VERSION_CMD` and `READ_BD_ADDR_CMD` still lack status guards** and can throw on a non-zero status with empty results. Same class as the buffer-size crash above, but not newly reachable, so left for a separate hardening pass — as is the fact that these guards check `status === 0` rather than `result.length`.
- **`isUserChannel()` is arguably the wrong predicate for the `usb` and `uart` drivers**, which call `bindUser()` internally, so on Linux they still won't answer an L2CAP Connection Parameter Update Request. Pre-existing; the real predicate is "is a kernel host stack managing this link".
- **`getAclBuffers()` can still hang if no Command Complete arrives at all** — e.g. a controller answering with Command Status instead. Closing that needs a deadline, which felt like scope creep here.

## Note on the issues around this one

I filed several related issues off the back of a `btmon` capture, and I got the central attribution wrong in #97 and #98 — I read kernel-originated commands as `bluetoothd` auto-connect when they were `kernelConnectWorkArounds` in the native dependency doing its documented raw-mode L2CAP routing. Both are corrected with comments. This PR is unaffected: it derives entirely from noble's own code plus commands absent from the capture, with no attribution reasoning involved.
