### PR TITLE
fix(hci): never reset a live controller, and fix the dev-up poll timer

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -184,8 +184,8 @@ NobleBindings.prototype.onStateChange = function (state) {
 
   // If we are powered on and we are powered off, disconnect all connections
   if (this._state === 'poweredOn' && state === 'poweredOff') {
-    for (const handle in this._handles) {
-      this.onDisconnComplete(handle, 0x03); // Hardward Failure
+    for (const handle of Object.keys(this._aclStreams)) {
+      this.onDisconnComplete(handle, 0x03); // Hardware Failure
     }
 
     this._connectionQueue = [];

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -104,6 +104,7 @@ const Hci = function (options) {
   
   this._isStarted = false;
   this._isDevUp = null;
+  this._devUpPollTimer = null;
   this._isExtended = 'extended' in options && options.extended;
   this._state = null;
   this._bindParams = 'bindParams' in options ? options.bindParams : undefined;
@@ -193,20 +194,22 @@ Hci.prototype.pollIsDevUp = function () {
         this._socket.removeAllListeners();
         this._state = null;
         this.init();
-        return;
+      } else {
+        this.setSocketFilter();
+        this.readLeSupportedFeatures();
+        // Subsequent calls moved to processCmdCompleteEvent for LE_READ_LOCAL_SUPPORTED_FEATURES
       }
-
-      this.setSocketFilter();
-      this.readLeSupportedFeatures();
-      // Subsequent calls moved to processCmdCompleteEvent for LE_READ_LOCAL_SUPPORTED_FEATURES
     } else {
       this.emit('stateChange', 'poweredOff');
     }
 
     this._isDevUp = isDevUp;
   }
-  if (this._isStarted) {
-    setTimeout(this.pollIsDevUp.bind(this), 1000);
+  if (this._isStarted && this._devUpPollTimer === null) {
+    this._devUpPollTimer = setTimeout(() => {
+      this._devUpPollTimer = null;
+      this.pollIsDevUp();
+    }, 1000);
   }
 };
 
@@ -285,6 +288,12 @@ Hci.prototype.setEventMask = function () {
 };
 
 Hci.prototype.reset = function () {
+  if (this._aclConnections.size > 0) {
+    debug(`reset - refusing while ${this._aclConnections.size} ACL connection(s) are active`);
+    this.afterReset();
+    return;
+  }
+
   const cmd = Buffer.alloc(4);
 
   // header
@@ -298,9 +307,28 @@ Hci.prototype.reset = function () {
   this._socket.write(cmd);
 };
 
+Hci.prototype.afterReset = function () {
+  if (this._isExtended) {
+    this.setCodedPhySupport();
+  }
+  this.setEventMask();
+  this.setLeEventMask();
+  this.readLocalVersion();
+  this.readBdAddr();
+  this.emit('reset');
+};
+
 Hci.prototype.stop = function () {
   this._socket.stop();
   this._isStarted = false;
+
+  if (this._devUpPollTimer !== null) {
+    clearTimeout(this._devUpPollTimer);
+    this._devUpPollTimer = null;
+  }
+
+  this._aclConnections.clear();
+  this._aclQueue = [];
 };
 
 Hci.prototype.readSupportedCommands = function () {
@@ -767,7 +795,11 @@ Hci.prototype.flushAcl = async function () {
   const aclBuffers = await this.getAclBuffers();
   while (this._aclQueue.length > 0 && pendingPackets() < aclBuffers.num) {
     const { handle, packet } = this._aclQueue.shift();
-    this._aclConnections.get(handle).pending++;
+    const connection = this._aclConnections.get(handle);
+    if (!connection) {
+      continue;
+    }
+    connection.pending++;
     debug(`write acl data packet - writing: ${packet.toString('hex')}`);
     this._socket.write(packet);
   }
@@ -953,14 +985,7 @@ Hci.prototype.onSocketError = function (error) {
 
 Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
   if (cmd === RESET_CMD) {
-    if (this._isExtended) {
-      this.setCodedPhySupport();
-    }
-    this.setEventMask();
-    this.setLeEventMask();
-    this.readLocalVersion();
-    this.readBdAddr();
-    this.emit('reset');
+    this.afterReset();
   } else if (cmd === LE_READ_LOCAL_SUPPORTED_FEATURES && status === 0) {
     // Set _isExtended based on leExtendedAdvertising bit (12)
     this._isExtended = (result[1] & (1 << 4)) !== 0;

--- a/test/lib/hci-socket/bindings.test.js
+++ b/test/lib/hci-socket/bindings.test.js
@@ -555,6 +555,84 @@ describe('hci-socket bindings', () => {
       expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
       expect(bindings._hci.createLeConn).toHaveBeenCalledWith('bb:bb:bb:bb:bb:bb', 'random', {}, true);
     });
+
+    it('poweredOn -> poweredOff disconnects all live connections exactly once without throwing', () => {
+      const disconnectCallback = jest.fn();
+      const gattSpy1 = { removeAllListeners: jest.fn() };
+      const signalingSpy1 = { removeAllListeners: jest.fn() };
+      const gattSpy2 = { removeAllListeners: jest.fn() };
+      const signalingSpy2 = { removeAllListeners: jest.fn() };
+      const aclStreamSpy1 = { push: jest.fn() };
+      const aclStreamSpy2 = { push: jest.fn() };
+
+      const handle1 = 1;
+      const handle2 = 2;
+      const uuid1 = 'uuid1';
+      const uuid2 = 'uuid2';
+
+      bindings._handles[uuid1] = handle1;
+      bindings._handles[handle1] = uuid1;
+      bindings._handles[uuid2] = handle2;
+      bindings._handles[handle2] = uuid2;
+
+      bindings._aclStreams[handle1] = aclStreamSpy1;
+      bindings._aclStreams[handle2] = aclStreamSpy2;
+      bindings._gatts[handle1] = gattSpy1;
+      bindings._gatts[uuid1] = gattSpy1;
+      bindings._gatts[handle2] = gattSpy2;
+      bindings._gatts[uuid2] = gattSpy2;
+      bindings._signalings[handle1] = signalingSpy1;
+      bindings._signalings[uuid1] = signalingSpy1;
+      bindings._signalings[handle2] = signalingSpy2;
+      bindings._signalings[uuid2] = signalingSpy2;
+
+      bindings._state = 'poweredOn';
+      bindings.on('disconnect', disconnectCallback);
+
+      expect(() => bindings.onStateChange('poweredOff')).not.toThrow();
+
+      expect(disconnectCallback).toHaveBeenCalledTimes(2);
+      expect(disconnectCallback).toHaveBeenCalledWith(uuid1, 0x03);
+      expect(disconnectCallback).toHaveBeenCalledWith(uuid2, 0x03);
+
+      expect(aclStreamSpy1.push).toHaveBeenCalledWith(null, null);
+      expect(aclStreamSpy2.push).toHaveBeenCalledWith(null, null);
+      expect(gattSpy1.removeAllListeners).toHaveBeenCalledTimes(1);
+      expect(gattSpy2.removeAllListeners).toHaveBeenCalledTimes(1);
+      expect(signalingSpy1.removeAllListeners).toHaveBeenCalledTimes(1);
+      expect(signalingSpy2.removeAllListeners).toHaveBeenCalledTimes(1);
+
+      should(bindings._handles).deepEqual({});
+      should(bindings._aclStreams).deepEqual({});
+      should(bindings._gatts).deepEqual({});
+      should(bindings._signalings).deepEqual({});
+    });
+
+    it('poweredOn -> poweredOff does not throw for a hypothetical uuid that would sort before its handle', () => {
+      // addressToId always yields a 12-hex-char uuid, never an array index, so this shape is unreachable via connect()
+      const disconnectCallback = jest.fn();
+      const gattSpy = { removeAllListeners: jest.fn() };
+      const signalingSpy = { removeAllListeners: jest.fn() };
+
+      const handle = 10;
+      const uuid = '1';
+
+      bindings._handles[uuid] = handle;
+      bindings._handles[handle] = uuid;
+      bindings._aclStreams[handle] = [];
+      bindings._gatts[handle] = gattSpy;
+      bindings._gatts[uuid] = gattSpy;
+      bindings._signalings[handle] = signalingSpy;
+      bindings._signalings[uuid] = signalingSpy;
+
+      bindings._state = 'poweredOn';
+      bindings.on('disconnect', disconnectCallback);
+
+      expect(() => bindings.onStateChange('poweredOff')).not.toThrow();
+
+      expect(disconnectCallback).toHaveBeenCalledTimes(1);
+      expect(disconnectCallback).toHaveBeenCalledWith(uuid, 0x03);
+    });
   });
 
   it('onAddressChange', () => {

--- a/test/lib/hci-socket/hci.test.js
+++ b/test/lib/hci-socket/hci.test.js
@@ -239,25 +239,91 @@ describe('hci-socket hci', () => {
       assert.notCalled(callback);
     });
 
-    it('should emit stateChange', () => {
-      hci._socket.isDevUp.returns(false);
+    it('should keep exactly one pending timer no matter how many times it is invoked within the same tick', () => {
+      hci._isStarted = true;
+      hci._socket.isDevUp.returns(true);
+      hci._isDevUp = true;
+
+      for (let i = 0; i < 10; i++) {
+        hci.pollIsDevUp();
+      }
+
+      should(sinon.clock.countTimers()).equal(1);
+    });
+
+    it('should keep polling normally across ticks with a single timer', () => {
+      hci._isStarted = true;
+      hci._socket.isDevUp.returns(true);
       hci._isDevUp = true;
 
       hci.pollIsDevUp();
+      should(sinon.clock.countTimers()).equal(1);
+
+      sinon.clock.tick(1000);
+      should(sinon.clock.countTimers()).equal(1);
+
+      sinon.clock.tick(1000);
+      should(sinon.clock.countTimers()).equal(1);
+    });
+
+    it('should not re-arm the poll timer after stop()', () => {
+      hci._socket.stop = sinon.spy();
+      hci._isStarted = true;
+      hci._socket.isDevUp.returns(true);
+      hci._isDevUp = true;
+
+      hci.pollIsDevUp();
+      should(sinon.clock.countTimers()).equal(1);
+
+      hci.stop();
+      should(sinon.clock.countTimers()).equal(0);
+
+      sinon.clock.tick(1000);
+      should(sinon.clock.countTimers()).equal(0);
+      assert.notCalled(hci.init);
+    });
+
+    it('should re-initialise after a genuine power-off followed by power-on', () => {
+      hci._state = 'poweredOn';
+      hci._isDevUp = true;
+
+      hci._socket.isDevUp.returns(false);
+      hci.pollIsDevUp();
 
       assert.calledOnceWithExactly(callback, 'poweredOff');
+      should(hci._state).equal('poweredOff');
 
-      assert.notCalled(hci._socket.removeAllListeners);
-      assert.notCalled(hci.init);
-      assert.notCalled(hci.setSocketFilter);
-      assert.notCalled(hci.setEventMask);
-      assert.notCalled(hci.setLeEventMask);
-      assert.notCalled(hci.readLocalVersion);
-      assert.notCalled(hci.writeLeHostSupported);
-      assert.notCalled(hci.readLeHostSupported);
-      assert.notCalled(hci.readLeBufferSize);
-      assert.notCalled(hci.readBdAddr);
-      assert.notCalled(hci.setCodedPhySupport);
+      hci._socket.isDevUp.returns(true);
+      hci.pollIsDevUp();
+
+      assert.calledOnceWithExactly(hci._socket.removeAllListeners);
+      assert.calledOnceWithExactly(hci.init);
+      should(hci._state).equal(null);
+    });
+
+    it('should end up with exactly one pending timer once init() re-enters pollIsDevUp during recovery', () => {
+      hci.init = Hci.prototype.init;
+      hci._isStarted = true;
+      hci._state = 'poweredOff';
+      hci._isDevUp = false;
+      hci._socket.isDevUp.returns(true);
+
+      hci.pollIsDevUp();
+
+      should(sinon.clock.countTimers()).equal(1);
+    });
+
+    it('should still leave a pending poll timer when init() throws during recovery', () => {
+      hci.init = Hci.prototype.init;
+      hci._isStarted = true;
+      hci._state = 'poweredOff';
+      hci._isDevUp = false;
+      hci._socket.isDevUp.returns(true);
+      hci._socket.start = sinon.stub().throws(new Error('boom'));
+
+      hci.pollIsDevUp();
+
+      should(sinon.clock.countTimers()).equal(1);
     });
   });
 
@@ -276,9 +342,81 @@ describe('hci-socket hci', () => {
     assert.calledOnceWithExactly(hci._socket.write, Buffer.from([1, 1, 0x0c, 0x08, 0xff, 0xff, 0xfb, 0xff, 0x07, 0xf8, 0xbf, 0x3d]));
   });
 
-  it('should reset', () => {
-    hci.reset();
-    assert.calledOnceWithExactly(hci._socket.write, Buffer.from([1, 3, 0x0c, 0]));
+  describe('reset', () => {
+    it('should write the reset command when no ACL connections are active', () => {
+      hci.reset();
+      assert.calledOnceWithExactly(hci._socket.write, Buffer.from([1, 3, 0x0c, 0]));
+    });
+
+    it('should not write the reset command while an ACL connection is active, but still emit reset and run the post-reset chain', () => {
+      hci.setEventMask = sinon.spy();
+      hci.setLeEventMask = sinon.spy();
+      hci.readLocalVersion = sinon.spy();
+      hci.readBdAddr = sinon.spy();
+      const resetCallback = sinon.spy();
+      hci.on('reset', resetCallback);
+
+      hci._aclConnections.set(4404, { pending: 0 });
+
+      hci.reset();
+
+      assert.notCalled(hci._socket.write);
+      assert.calledOnceWithExactly(hci.setEventMask);
+      assert.calledOnceWithExactly(hci.setLeEventMask);
+      assert.calledOnceWithExactly(hci.readLocalVersion);
+      assert.calledOnceWithExactly(hci.readBdAddr);
+      assert.calledOnce(resetCallback);
+    });
+
+    it('should still reach createLeConnAfterReset via createLeConn while an ACL connection is active', () => {
+      hci.setEventMask = sinon.spy();
+      hci.setLeEventMask = sinon.spy();
+      hci.readLocalVersion = sinon.spy();
+      hci.readBdAddr = sinon.spy();
+      hci.createLeConnAfterReset = sinon.spy();
+      hci._aclConnections.set(4404, { pending: 0 });
+
+      const address = 'aa:bb:cc:dd:ee:ff';
+      const addressType = 'random';
+      const parameters = { minInterval: 0x0060, maxInterval: 0x00c0 };
+
+      hci.createLeConn(address, addressType, parameters, true);
+
+      assert.notCalled(hci._socket.write);
+      assert.calledOnceWithExactly(hci.createLeConnAfterReset, address, addressType, parameters);
+    });
+
+    it('should resume writing the reset command once the ACL connections are gone', () => {
+      hci.setEventMask = sinon.spy();
+      hci.setLeEventMask = sinon.spy();
+      hci.readLocalVersion = sinon.spy();
+      hci.readBdAddr = sinon.spy();
+
+      hci._aclConnections.set(4404, { pending: 0 });
+      hci.reset();
+      assert.notCalled(hci._socket.write);
+
+      hci._aclConnections.delete(4404);
+      hci.reset();
+
+      assert.calledOnceWithExactly(hci._socket.write, Buffer.from([1, 3, 0x0c, 0]));
+    });
+  });
+
+  describe('stop', () => {
+    it('should clear ACL bookkeeping so a subsequent reset() is not left permanently refused', () => {
+      hci._socket.stop = sinon.spy();
+      hci._aclConnections.set(4404, { pending: 0 });
+      hci._aclQueue.push({ handle: 4404, packet: Buffer.from([0x00]) });
+
+      hci.stop();
+
+      should(hci._aclConnections.size).equal(0);
+      should(hci._aclQueue).be.empty();
+
+      hci.reset();
+      assert.calledOnceWithExactly(hci._socket.write, Buffer.from([1, 3, 0x0c, 0]));
+    });
   });
 
   it('should readSupportedCommands', () => {
@@ -540,6 +678,26 @@ describe('hci-socket hci', () => {
     ]);
   });
 
+  it('should not produce an unhandled rejection when stop() clears _aclConnections while writeAclDataPkt is in flight', async () => {
+    const handle = 4404;
+    const cid = 4;
+    const data = Buffer.from([1, 2, 3]);
+
+    hci._socket.stop = sinon.spy();
+    hci._aclConnections.set(handle, { pending: 0 });
+    jest.spyOn(hci, 'flushAcl');
+
+    const writePromise = hci.writeAclDataPkt(handle, cid, data);
+
+    hci.stop();
+    hci.setAclBuffers(20, 4);
+
+    await writePromise;
+
+    await expect(hci.flushAcl.mock.results[0].value).resolves.toBeUndefined();
+    should(hci._aclConnections.size).equal(0);
+  });
+
   describe('flushAcl', () => {
     it('should not write flush on no pending connections', () => {
       const queue = [
@@ -622,6 +780,27 @@ describe('hci-socket hci', () => {
       assert.calledWithExactly(hci._socket.write, Buffer.from([0x02, 0x34, 0x12, 0x03, 0x00, 0x09, 0x0a, 0x0b]));
       assert.calledWithExactly(hci._socket.write, Buffer.from([0x02]));
 
+      should(hci._aclQueue).be.empty();
+    });
+
+    it('should skip a queued packet whose connection is gone, without throwing, and keep draining the rest', async () => {
+      const queue = [
+        {
+          handle: 9999, // e.g. removed from _aclConnections by stop() while this was queued
+          packet: Buffer.from([0xff])
+        },
+        {
+          handle: 4660,
+          packet: Buffer.from([0x02, 0x34, 0x12, 0x08, 0x00, 0x07, 0x00, 0x59, 0x01, 0x05, 0x06, 0x07, 0x08])
+        }
+      ];
+      hci._aclQueue = [...queue];
+      hci._aclConnections.set(4660, { pending: 0 });
+      hci._aclBuffers = { num: 12 };
+
+      await hci.flushAcl();
+
+      assert.calledOnceWithExactly(hci._socket.write, Buffer.from([0x02, 0x34, 0x12, 0x08, 0x00, 0x07, 0x00, 0x59, 0x01, 0x05, 0x06, 0x07, 0x08]));
       should(hci._aclQueue).be.empty();
     });
   });
@@ -1859,6 +2038,18 @@ describe('hci-socket hci', () => {
     should(hci._aclConnections.get(4404)).deepEqual({ pending: 0 });
   });
 
+  it('should emit leConnComplete but not record the connection on failed status', () => {
+    const status = 1;
+    const data = Buffer.from([0x34, 0x11, 4, 1, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 2, 1, 4, 3, 7, 8, 9]);
+    const callback = sinon.spy();
+
+    hci.on('leConnComplete', callback);
+    hci.processLeConnComplete(status, data);
+
+    assert.calledOnceWithExactly(callback, status, 4404, 4, 'random', 'ff:ee:dd:cc:bb:aa', 322.5, 772, 20550, 9);
+    should(hci._aclConnections.size).equal(0);
+  });
+
   it('should emit leConnComplete on processLeEnhancedConnComplete', () => {
     const status = 0;
     const data = Buffer.from([0x34, 0x11, 4, 1, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 2, 1, 4, 3, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]);
@@ -1952,6 +2143,18 @@ describe('hci-socket hci', () => {
     assert.notCalled(callback);
     expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('too short'));
     consoleSpy.mockRestore();
+  });
+
+  it('should still write reset after a failed connection-complete recorded no connection (regression: guard must not jam)', () => {
+    const status = 1;
+    const data = Buffer.from([0x34, 0x11, 4, 1, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 2, 1, 4, 3, 7, 8, 9]);
+
+    hci.processLeConnComplete(status, data);
+    should(hci._aclConnections.size).equal(0);
+
+    hci.reset();
+
+    assert.calledOnceWithExactly(hci._socket.write, Buffer.from([1, 3, 0x0c, 0]));
   });
 
   describe('processLeAdvertisingReport', () => {


### PR DESCRIPTION
Fixes #98. Partially addresses #102 — see the retraction below.

## Reset guard (#98)

`HCI_Reset` was reachable on a live link from two places: `init()` reset unconditionally, and `createLeConn`'s reset was guarded only by its callers via `Object.keys(this._handles).length === 0`. Resetting a controller with an established ACL link tears that link down mid-session, so the primitive itself now refuses.

The post-reset command chain moves into `afterReset()` and runs on the refusal path too, so neither `createLeConn`'s `once('reset')` continuation nor `init()`'s setup chain stalls when the reset is declined.

**Prerequisite in the same change:** `processLeConnComplete` and `processLeEnhancedConnComplete` recorded every `LE Connection Complete` regardless of status, and the only removal is on `EVT_DISCONN_COMPLETE`, which never arrives for a connection that never existed. So a failed attempt left an entry forever, and with the guard above that would refuse every subsequent reset for the process lifetime. `cancelConnect` is a realistic trigger. Both now record only on `status === 0`, while `emit('leConnComplete', status, ...)` stays unconditional so `NobleBindings.onLeConnComplete` still sees failures.

I have deliberately **not** touched what `createLeConn`'s reset is for. My earlier analysis of it in #98 was wrong and is retracted in that issue; this PR only stops it firing when it would destroy a live link.

## Poll timer

`pollIsDevUp` rescheduled itself unconditionally on every invocation, and it is also the socket's `state` handler. `emit('state', ...)` fires at `uart.js:86`, `uart.js:193` and `usb.js:281` in `@stoprocent/bluetooth-hci-socket`, so with the JS drivers every reset forked another perpetual 1 Hz timer and nothing ever cancelled one. Now a single pending handle is tracked and reused, and cleared in `stop()`.

That also let the early `return` in the recovery branch go, which was masking a latent failure it had been hiding: the `return` skipped the scheduling block, so the chain depended entirely on `init()` re-arming it — and if `init()` throws, its `catch` emits `unsupported` without re-arming. The Linux native driver emits no `state` events, so polling died permanently. There is a test for the throwing case specifically.

## `stop()` and `flushAcl`

`stop()` now clears `_aclConnections` and `_aclQueue`; without it the new reset guard sees stale entries after a stop/init cycle and the controller is never reset on restart.

That clear introduces a crash unless `flushAcl` is guarded, so this PR guards it: `writeAclDataPkt` awaits `getAclBuffers()` *before* queueing and then calls `flushAcl()` un-awaited, so a GATT operation in flight when the application calls `noble.stop()` resumes to find its handle gone and dereferences `undefined` — an unhandled rejection, i.e. process termination on Node >= 18. The pre-existing `onStateChange` clear has the same hazard, which is why the guard belongs in `flushAcl`.

**Note:** this `flushAcl` hunk is identical to one in #111. That duplication is deliberate — I am not willing to ship a branch that can crash the process depending on merge order. It should resolve trivially whichever lands first.

## Retraction: the #102 debounce is withdrawn

This PR originally also debounced the adapter-down transition, per #102. **That was wrong and it is not in this PR.** Full detail is in a correction comment on #102; the short version:

`HCI_UP == false` does not mean "the adapter may be blipping while our links survive". It means the controller was closed and every ACL link is already destroyed, with no `HCI_Disconnection_Complete` delivered to a raw HCI socket. Debouncing the `poweredOff` emit therefore protects nothing and suppresses the cleanup `onStateChange` performs. Combined with this PR's reset guard, a one-second `hciconfig down; up` left a stale `_aclConnections` entry that latched the guard permanently, stopped `flushAcl` draining for *all* connections once the dead handle's `pending` reached `aclBuffers.num`, and left `disconnect()` on that handle never settling. Previously self-healing.

What survives from #102 is in this PR: the poll timer leak and the `stop()` cleanup. #102's enumeration-order claim is also withdrawn — `addressToId` always produces a 12-hex-character uuid, which can never be a canonical array index, so the `TypeError` I described there is unreachable. The `Object.keys(this._aclStreams)` iteration is kept as a readability change and the commit message and test comment both say so rather than claiming a fix.

## Tests

`npx jest`: 19 suites, 730 passed, 1 skipped, 0 failures (baseline on `main` is 714). `npm run lint` clean.

Every production hunk was mutation-tested by reverting it and confirming a test fails. Two notes on that, because they changed what the tests look like:

- The non-throwing "exactly one timer" test does not discriminate the early-`return` removal — both paths net one timer when `init()` succeeds. Only the throwing case does, so that test exists specifically.
- The realistic two-connection test for the bindings loop passes on the unchanged code, which is how I established the enumeration-order claim was wrong. The remaining digit-only-uuid test is labelled as pinning a hypothetical shape, not a reachable one.

## Known limitation

`_aclConnections` is populated from every `LE Connection Complete` the socket observes, and on a Linux raw HCI socket that includes connections made by other processes. A foreign incoming link is recorded here but skipped by `NobleBindings.onLeConnComplete`, so `bindings._handles` stays empty, `bindings.connect` asks for `reset = true`, and the guard silently no-ops it for as long as that foreign link lives. Refusing to reset while *anyone's* link is live is arguably the correct behaviour, so I have not tried to distinguish ownership here — flagging it because it is a path the guard changes.
