### PR TITLE
fix(hci): stop concurrent connects during a scan deadlocking each other

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -120,26 +120,29 @@ NobleBindings.prototype.connect = function (peripheralUuid, parameters = {}) {
   }
 
   // Add connection request to queue
-  this._connectionQueue.push({ 
-    id: peripheralUuid, 
-    address, 
-    addressType, 
+  this._connectionQueue.push({
+    id: peripheralUuid,
+    address,
+    addressType,
     params: parameters
   });
 
-  const processNextConnection = () => {
-    if (this._connectionQueue.length === 1) {
-      const nextConn = this._connectionQueue[0]; // Look at next connection but don't remove yet
-      this._hci.createLeConn(nextConn.address, nextConn.addressType, nextConn.params, Object.keys(this._handles).length === 0);
-    }
-  };
+  this.processConnectionQueue();
+};
+
+NobleBindings.prototype.processConnectionQueue = function () {
+  if (this._pendingConnectionUuid || this._connectionQueue.length === 0) {
+    return;
+  }
 
   if (this._isScanning) {
-    this.once('scanStop', processNextConnection);
     this.stopScanning();
-  } else {
-    processNextConnection();
+    return;
   }
+
+  const nextConn = this._connectionQueue[0];
+  this._pendingConnectionUuid = nextConn.id;
+  this._hci.createLeConn(nextConn.address, nextConn.addressType, nextConn.params, Object.keys(this._handles).length === 0);
 };
 
 NobleBindings.prototype.disconnect = function (peripheralUuid) {
@@ -151,6 +154,11 @@ NobleBindings.prototype.cancelConnect = function (peripheralUuid) {
   this._connectionQueue = this._connectionQueue.filter(
     (c) => c.id !== peripheralUuid
   );
+
+  if (this._pendingConnectionUuid === peripheralUuid) {
+    this._pendingConnectionUuid = null;
+  }
+
   this._hci.cancelConnect(this._handles[peripheralUuid]);
 };
 
@@ -179,6 +187,9 @@ NobleBindings.prototype.onStateChange = function (state) {
     for (const handle in this._handles) {
       this.onDisconnComplete(handle, 0x03); // Hardward Failure
     }
+
+    this._connectionQueue = [];
+    this._pendingConnectionUuid = null;
   }
 
   this._state = state;
@@ -223,6 +234,7 @@ NobleBindings.prototype.onScanStop = function () {
   this._isScanning = false;
   this._isScanningStarted = false;
   this.emit('scanStop');
+  this.processConnectionQueue();
 };
 
 NobleBindings.prototype.onDiscover = function (
@@ -399,14 +411,12 @@ NobleBindings.prototype.onLeConnComplete = function (
 
   // Remove the completed/failed connection attempt from queue
   this._connectionQueue.shift();
+  this._pendingConnectionUuid = null;
 
   this.emit('connect', uuid, error);
 
   // Process next connection in queue if any
-  if (this._connectionQueue.length > 0 && !this._isScanning) {
-    const nextConn = this._connectionQueue[0];
-    this._hci.createLeConn(nextConn.address, nextConn.addressType, nextConn.params, Object.keys(this._handles).length === 0);
-  }
+  this.processConnectionQueue();
 };
 
 NobleBindings.prototype.onLeConnUpdateComplete = function (

--- a/test/lib/hci-socket/bindings.test.js
+++ b/test/lib/hci-socket/bindings.test.js
@@ -278,10 +278,93 @@ describe('hci-socket bindings', () => {
       bindings._pendingConnectionUuid = 'pending-uuid';
 
       bindings.connect('peripheralUuid', 'parameters');
-      
+
       should(bindings._connectionQueue).length(1);
       should(bindings._connectionQueue[0].id).eql('peripheralUuid');
       should(bindings._connectionQueue[0].params).eql('parameters');
+    });
+
+    // Characterization test: this also passes unmodified against main.
+    it('a connection already in flight blocks createLeConn until it completes', () => {
+      bindings._hci.createLeConn = jest.fn();
+      bindings._addresses = { peripheralA: '112233445566', peripheralB: '998877665544' };
+      bindings._addresseTypes = { peripheralA: 'random', peripheralB: 'public' };
+
+      bindings.connect('peripheralA', { addressType: 'random' });
+
+      expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
+
+      bindings.connect('peripheralB', { addressType: 'public' });
+
+      // Second connect() queued behind the in-flight first attempt.
+      expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
+      should(bindings._connectionQueue).length(2);
+
+      bindings.onLeConnComplete(0, 'handle-a', 0, 'random', '11:22:33:44:55:66');
+
+      expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(2);
+      expect(bindings._hci.createLeConn).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false);
+    });
+
+    describe('regression: concurrent connects during a scan (issue #112)', () => {
+      it('two connects queued during scanning both reach createLeConn, one after the other completes', () => {
+        bindings._hci.createLeConn = jest.fn();
+        bindings._addresses = { peripheralA: '112233445566', peripheralB: '998877665544' };
+        bindings._addresseTypes = { peripheralA: 'random', peripheralB: 'public' };
+        bindings._isScanning = true;
+        bindings._isScanningStarted = true;
+
+        bindings.connect('peripheralA', { addressType: 'random' });
+        bindings.connect('peripheralB', { addressType: 'public' });
+
+        // Nothing may start while the scan hasn't actually stopped yet.
+        expect(bindings._hci.createLeConn).not.toHaveBeenCalled();
+        should(bindings._connectionQueue).length(2);
+
+        // Simulate the hardware reporting that scanning has actually stopped.
+        bindings.onScanStop();
+
+        expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
+        expect(bindings._hci.createLeConn).toHaveBeenCalledWith('112233445566', 'random', { addressType: 'random' }, true);
+
+        bindings.onLeConnComplete(0, 'handle-a', 0, 'random', '11:22:33:44:55:66');
+
+        expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(2);
+        expect(bindings._hci.createLeConn).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false);
+      });
+
+      it('does not strand the queue when scanning resumes (via startScanning/onScanStart) before the second entry starts', () => {
+        bindings._hci.createLeConn = jest.fn();
+        bindings._addresses = { peripheralA: '112233445566', peripheralB: '998877665544' };
+        bindings._addresseTypes = { peripheralA: 'random', peripheralB: 'public' };
+        bindings._isScanning = true;
+        bindings._isScanningStarted = true;
+
+        bindings.connect('peripheralA', { addressType: 'random' });
+        bindings.connect('peripheralB', { addressType: 'public' });
+
+        bindings.onScanStop();
+        expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
+
+        // Drive scanning resumption through the same entry points a discovery
+        // loop uses (startScanning() then the gap's scanStart callback), not by
+        // poking _isScanningStarted directly.
+        bindings.startScanning();
+        bindings.onScanStart();
+
+        bindings.onLeConnComplete(0, 'handle-a', 0, 'random', '11:22:33:44:55:66');
+
+        // peripheralB must not start while scanning is active again.
+        expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
+        should(bindings._connectionQueue).length(1);
+
+        // Scanning genuinely stops again; peripheralB must now proceed.
+        bindings.onScanStop();
+
+        expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(2);
+        // peripheralA's handle is now registered (its leConnComplete already succeeded), so reset is false.
+        expect(bindings._hci.createLeConn).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false);
+      });
     });
   });
 
@@ -451,6 +534,26 @@ describe('hci-socket bindings', () => {
       expect(stateChange).toHaveBeenCalledWith('unsupported');
       expect(console.log).toHaveBeenCalledTimes(3);
       expect(console.log).toHaveBeenCalledWith(expect.stringContaining('adapter does not support Bluetooth'));
+    });
+
+    it('poweredOn -> poweredOff with an attempt in flight clears the queue and in-flight flag, and a later connect() starts normally (issue #112)', () => {
+      bindings._state = 'poweredOn';
+      bindings._connectionQueue.push({ id: 'queuedPeripheral', address: 'aa:aa:aa:aa:aa:aa', addressType: 'random', params: {} });
+      bindings._pendingConnectionUuid = 'queuedPeripheral';
+
+      bindings.onStateChange('poweredOff');
+
+      should(bindings._connectionQueue).length(0);
+      should(bindings._pendingConnectionUuid).equal(null);
+
+      bindings._hci.createLeConn = jest.fn();
+      bindings._addresses = { peripheralUuid: 'bb:bb:bb:bb:bb:bb' };
+      bindings._addresseTypes = { peripheralUuid: 'random' };
+      bindings.onStateChange('poweredOn');
+      bindings.connect('peripheralUuid', {});
+
+      expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
+      expect(bindings._hci.createLeConn).toHaveBeenCalledWith('bb:bb:bb:bb:bb:bb', 'random', {}, true);
     });
   });
 
@@ -778,6 +881,21 @@ describe('hci-socket bindings', () => {
         message: 'HCI Error: Unknown (0x2)' 
       }));
 
+      should(bindings._connectionQueue).length(0);
+    });
+
+    // Characterization test: this also passes unmodified against main.
+    it('reads the mtu from the queue head params before shifting it off', () => {
+      const status = 0;
+      const handle = 'handle';
+      const role = 0;
+      const addressType = 'random';
+      const address = 'address:split:by:separator';
+
+      bindings._connectionQueue.push({ id: 'pending_uuid', params: { mtu: 100 } });
+      bindings.onLeConnComplete(status, handle, role, addressType, address);
+
+      expect(Gatt).toHaveBeenCalledWith(address, expect.anything(), 100);
       should(bindings._connectionQueue).length(0);
     });
 


### PR DESCRIPTION
Addresses the first of the two bugs in #112. Please do not auto-close that issue — the second bug is deliberately not fixed here, for reasons below.

## The bug

`connect()` decided whether to start an attempt by testing `_connectionQueue.length === 1`, but that test ran *after* the push, and each caller registered its own `once('scanStop', ...)` continuation:

```js
  this._connectionQueue.push({ id: peripheralUuid, address, addressType, params: parameters });

  const processNextConnection = () => {
    if (this._connectionQueue.length === 1) { ... }
  };

  if (this._isScanning) {
    this.once('scanStop', processNextConnection);
    this.stopScanning();
  }
```

Two `connect()` calls while `_isScanning` is true: both push, both register, both continuations fire on `scanStop`, both see a length of 2, both return. `createLeConn` is never issued, so no `LE Connection Complete` ever arrives, so nothing advances the queue. Both callers hang, and every later `connect()` queues behind a head that will never move — silently, with no error and no log.

Any application that discovers several peripherals and connects without serialising will hit this.

There was a second, quieter route: `onLeConnComplete`'s pump was conditional on `!this._isScanning`, so if a scan had resumed by the time a connection completed, the next queued entry was never started either.

## The change

Track the in-flight attempt explicitly rather than inferring it from the queue length, and funnel every start through one idempotent `processConnectionQueue`, called from `connect()`, `onScanStop()`, `onLeConnComplete()` and `cancelConnect()`.

The scan-stop trigger lives in `onScanStop` rather than in a per-caller continuation. That matters beyond tidiness: `noble.js`'s discovery loop can restart scanning as soon as it observes `scanStop`, which would consume a one-shot listener before the second queued entry started. Firing on every stop closes that, and it also removes the `once` registrations that accumulated one per `connect()`.

`_pendingConnectionUuid` was already declared in the constructor and never used anywhere; it is now the in-flight marker.

The queue and the flag are cleared on the `poweredOn` to `poweredOff` teardown, silently. An outstanding attempt has no handle yet, so the existing disconnect loop never reaches it, and without this the new flag would stay set and latch the queue across a power cycle — worse than the current behaviour.

## Scope: what is deliberately not here

This started much larger and I cut it back after adversarial review found the extra work was, on several axes, worse than `main`. Recording the reasons so they are not rediscovered:

- **Releasing queued callers with an error on teardown** (#112's second bug). Emitting `connect(uuid, error)` synchronously makes noble's `_onConnect` set the peripheral state to `error`, and `_cleanupPeriperals` then treats that as needing teardown and fires a `disconnect` event for a peripheral that was only ever *connecting*. It also opens a reentrancy hole: a retry from the error handler writes `createLeConn` to a socket `stop()` is about to close. Both demonstrated. Needs a lifecycle flag and a look at noble's cleanup rules, not a patch here.
- **Matching completions against the in-flight attempt.** `onLeConnComplete` credits every completion to `_connectionQueue[0]` regardless of which peer completed, so a foreign or stale completion consumes the real in-flight entry, applies the wrong MTU, and leaves that caller unanswered. My attempt at an address match introduced a hard crash, because `Hci.processCmdStatusEvent` emits `leConnComplete` with only `status` — `address` is `undefined`, and `addressToId(undefined)` throws inside the socket `data` listener, uncaught. Fixing this properly needs the `hci.js` side first (the `data.every(byte => byte === 0)` guard also swallows genuine failure completions), and `hci.js` has two other PRs in flight.
- **`cancelConnect` semantics.** `Hci.cancelConnect()` takes no argument and cancels whichever initiator the controller currently has pending, so cancelling a merely-queued entry cancels somebody else's attempt. Left alone here apart from clearing the in-flight flag, and the existing `TODO` on that function is restored — it is still an open question.
- **`connect()` while the adapter is not `poweredOn`** latches the queue with nothing to release it. A guard fixes it but changes public behaviour (fail fast instead of hang) and required touching about two dozen existing test bodies, so it wants its own reviewed change.
- **Duplicate queue entries for one uuid** produce two `connect` answers for one request and can mark a live connection `error`. Unchanged from `main`.

I will file the ones that are not already tracked.

## Tests

`npx jest`: 19 suites, 719 passed, 1 skipped, 0 failures (baseline on `main` is 714). `npm run lint` clean.

The two deadlock regression tests were verified against `main`'s unmodified `bindings.js` and both fail there, so they target the real bug rather than passing vacuously. Two other tests in the touched blocks — `a connection already in flight blocks createLeConn until it completes` and `reads the mtu from the queue head params before shifting it off` — also pass unmodified against `main`; they are labelled in the file as characterization tests, because they document existing behaviour rather than evidencing this fix.
