### PR TITLE
fix(hci): harden LE Connection Complete parsing and don't record failed connections

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -1089,6 +1089,10 @@ Hci.prototype.processLeMetaEvent = function (eventType, numReports, data) {
 };
 
 Hci.prototype.processLeConnComplete = function (status, data) {
+  if (data.length < 17) {
+    console.warn(`processLeConnComplete: Caught illegal packet (too short: ${data.length} < 17)`);
+    return;
+  }
   if (data.every(byte => byte === 0)) {
     return;
   }
@@ -1115,7 +1119,9 @@ Hci.prototype.processLeConnComplete = function (status, data) {
   debug(`\t\t\tsupervision timeout = ${supervisionTimeout}`);
   debug(`\t\t\tmaster clock accuracy = ${masterClockAccuracy}`);
 
-  this._aclConnections.set(handle, { pending: 0 });
+  if (status === 0) {
+    this._aclConnections.set(handle, { pending: 0 });
+  }
 
   this.emit(
     'leConnComplete',
@@ -1132,6 +1138,10 @@ Hci.prototype.processLeConnComplete = function (status, data) {
 };
 
 Hci.prototype.processLeEnhancedConnComplete = function (status, data) {
+  if (data.length < 29) {
+    console.warn(`processLeEnhancedConnComplete: Caught illegal packet (too short: ${data.length} < 29)`);
+    return;
+  }
   if (data.every(byte => byte === 0)) {
     return;
   }
@@ -1176,7 +1186,9 @@ Hci.prototype.processLeEnhancedConnComplete = function (status, data) {
   debug(`\t\t\tsupervision timeout = ${supervisionTimeout}`);
   debug(`\t\t\tmaster clock accuracy = ${masterClockAccuracy}`);
 
-  this._aclConnections.set(handle, { pending: 0 });
+  if (status === 0) {
+    this._aclConnections.set(handle, { pending: 0 });
+  }
 
   this.emit(
     'leConnComplete',
@@ -1341,7 +1353,20 @@ Hci.prototype.processLeConnUpdateComplete = function (status, data) {
 Hci.prototype.processCmdStatusEvent = function (cmd, status) {
   if (cmd === LE_CREATE_CONN_CMD || cmd === LE_CREATE_EXTENDED_CONN_CMD) {
     if (status !== 0) {
-      this.emit('leConnComplete', status);
+      // No LE Connection Complete follows a failed Command Status, and on a shared raw socket
+      // this status may not belong to a command this instance issued, so nothing else is known.
+      this.emit(
+        'leConnComplete',
+        status,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined
+      );
     }
   }
 };

--- a/test/lib/hci-socket/hci.test.js
+++ b/test/lib/hci-socket/hci.test.js
@@ -1847,7 +1847,7 @@ describe('hci-socket hci', () => {
   });
 
   it('should emit leConnComplete', () => {
-    const status = 'status';
+    const status = 0;
     const data = Buffer.from([0x34, 0x11, 4, 1, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 2, 1, 4, 3, 7, 8, 9]);
     const callback = sinon.spy();
 
@@ -1860,7 +1860,7 @@ describe('hci-socket hci', () => {
   });
 
   it('should emit leConnComplete on processLeEnhancedConnComplete', () => {
-    const status = 'status';
+    const status = 0;
     const data = Buffer.from([0x34, 0x11, 4, 1, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 2, 1, 4, 3, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]);
     const callback = sinon.spy();
 
@@ -1870,6 +1870,88 @@ describe('hci-socket hci', () => {
     assert.calledOnceWithExactly(callback, status, 4404, 4, 'random', 'ff:ee:dd:cc:bb:aa', 5138.75, 4625, 51390, 21);
     should(hci._aclConnections).keys(4404);
     should(hci._aclConnections.get(4404)).deepEqual({ pending: 0 });
+  });
+
+  it('should not emit leConnComplete for an all-zero payload (garbage/truncated event guard)', () => {
+    const status = 0;
+    const data = Buffer.alloc(17);
+    const callback = sinon.spy();
+
+    hci.on('leConnComplete', callback);
+    hci.processLeConnComplete(status, data);
+
+    assert.notCalled(callback);
+    should(hci._aclConnections.size).equal(0);
+  });
+
+  it('should not emit leConnComplete on processLeEnhancedConnComplete for an all-zero payload (garbage/truncated event guard)', () => {
+    const status = 0;
+    const data = Buffer.alloc(29);
+    const callback = sinon.spy();
+
+    hci.on('leConnComplete', callback);
+    hci.processLeEnhancedConnComplete(status, data);
+
+    assert.notCalled(callback);
+    should(hci._aclConnections.size).equal(0);
+  });
+
+  it('should not register an ACL connection when the completion reports a failure status', () => {
+    const status = 0x02;
+    const data = Buffer.from([0x34, 0x11, 4, 1, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 2, 1, 4, 3, 7, 8, 9]);
+    const callback = sinon.spy();
+
+    hci.on('leConnComplete', callback);
+    hci.processLeConnComplete(status, data);
+
+    assert.calledOnceWithExactly(callback, status, 4404, 4, 'random', 'ff:ee:dd:cc:bb:aa', 322.5, 772, 20550, 9);
+    should(hci._aclConnections.size).equal(0);
+  });
+
+  it('should not register an ACL connection on processLeEnhancedConnComplete when the completion reports a failure status', () => {
+    const status = 0x02;
+    const data = Buffer.from([0x34, 0x11, 4, 1, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 2, 1, 4, 3, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22]);
+    const callback = sinon.spy();
+
+    hci.on('leConnComplete', callback);
+    hci.processLeEnhancedConnComplete(status, data);
+
+    assert.calledOnceWithExactly(callback, status, 4404, 4, 'random', 'ff:ee:dd:cc:bb:aa', 5138.75, 4625, 51390, 21);
+    should(hci._aclConnections.size).equal(0);
+  });
+
+  it('should not throw and should reject a too-short payload for processLeConnComplete', () => {
+    // Non-zero payload, one byte short of the 17 the field reads require - the all-zero
+    // guard must not be the only thing standing between this and a RangeError.
+    const status = 0;
+    const data = Buffer.from([0x34, 0x11, 4, 1, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 2, 1, 4, 3, 7, 8]);
+    const callback = sinon.spy();
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    hci.on('leConnComplete', callback);
+
+    expect(() => hci.processLeConnComplete(status, data)).not.toThrow();
+
+    assert.notCalled(callback);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('too short'));
+    consoleSpy.mockRestore();
+  });
+
+  it('should not throw and should reject a too-short payload for processLeEnhancedConnComplete', () => {
+    // Non-zero payload, one byte short of the 29 the field reads require - the all-zero
+    // guard must not be the only thing standing between this and a RangeError.
+    const status = 0;
+    const data = Buffer.from([0x34, 0x11, 4, 1, 0xaa, 0xbb, 0xcc, 0xdd, 0xee, 0xff, 2, 1, 4, 3, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20]);
+    const callback = sinon.spy();
+    const consoleSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+
+    hci.on('leConnComplete', callback);
+
+    expect(() => hci.processLeEnhancedConnComplete(status, data)).not.toThrow();
+
+    assert.notCalled(callback);
+    expect(consoleSpy).toHaveBeenCalledWith(expect.stringContaining('too short'));
+    consoleSpy.mockRestore();
   });
 
   describe('processLeAdvertisingReport', () => {
@@ -2049,7 +2131,18 @@ describe('hci-socket hci', () => {
         hci.on('leConnComplete', callback);
         hci.processCmdStatusEvent(cmd, 'status');
 
-        assert.calledOnceWithExactly(callback, 'status');
+        assert.calledOnceWithExactly(
+          callback,
+          'status',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined
+        );
       });
     });
   });


### PR DESCRIPTION
Addresses part of #117. Please don't auto-close it — the main thing that issue asks for is deliberately deferred, and I've [corrected the issue](https://github.com/stoprocent/noble/issues/117#issuecomment-5135856814) because two of its three proposals were wrong.

## What's here

**Record the ACL connection only on success.** Handle `0` is a legal ACL handle, so a failure completion could overwrite a live `{ pending: N }` entry with `{ pending: 0 }` — under-counting outstanding packets in `flushAcl`'s credit check and letting it issue writes past `aclBuffers.num`. Nothing removes such an entry either, since no `Disconnect Complete` arrives for a connection that never existed.

**Reject payloads too short for the fields being read.** Neither handler checked `data.length` before reading through offset 16 / offset 28, so a truncated event threw a `RangeError` out of the unguarded socket `data` listener and the process exited. `processLeExtendedAdvertisingReport` in the same file already guards this way, so this just brings the two completion handlers in line.

**Uniform `leConnComplete` arity from `processCmdStatusEvent`.** Being explicit: **this is a no-op today.** Trailing `undefined` arguments are indistinguishable to a JS listener, the event has exactly one consumer in the repo, and reverting it leaves every suite green except the two direct unit assertions on that function. It's here so the next parameter read added on that path fails visibly instead of silently seeing `undefined`.

The peer address is deliberately *not* recovered from the last issued `LE Create Connection`. On a shared raw socket, a Command Status for that opcode isn't guaranteed to belong to a command this instance issued, so a recovered address could be attributed to an unrelated failure — and the sole consumer never reads it on the failure path anyway.

## What's deferred, and why

#117's headline ask — stop discarding all-zero failure completions, so a failed attempt reaches bindings at all — **is not in this PR.** I implemented it, and adversarial review showed it trades one bug for another:

`NobleBindings.onLeConnComplete` shifts `_connectionQueue[0]` unconditionally, so once the `status 0x02` completion provoked by `LE_Create_Connection_Cancel` is no longer discarded, it gets attributed to whatever is at the head. Demonstrated: `connect(A)`, `connect(B)`, `cancelConnect(A)` fails **B** with `Unknown Connection Identifier (0x2)` although `createLeConn` was never called for it; with an empty queue it emits `connect` with `uuid === null`, surfacing as `warning: unknown peripheral null connected!`. Before the change B hung forever instead.

Closing that needs explicit in-flight tracking (#116) and the attribution fix (#118). This PR keeps the guard as-is so nothing regresses in the meantime.

I also **withdrew** #117's third proposal, to wrap `onSocketData` in a `try`/`catch`. That chain is entirely synchronous `emit` out to application code, so the catch becomes the process-wide sink for user-callback throws and leaves noble's own handlers half-executed — a throwing `peripheral.on('connect')` handler makes `connectAsync()` never settle; a throwing `mtu` consumer leaves `Gatt._currentCommand` non-null and deadlocks every later GATT operation on that peripheral. Converting loud crashes into silent permanent wedges is worse. The length checks above address the actual crash source instead.

## Overlap with in-flight work

The `_aclConnections` status guard is **the same hunk as one in #113**. That duplication is deliberate — this PR shouldn't depend on merge order for correctness. Whichever lands first, the other rebases trivially. No overlap with #111 (`processCmdCompleteEvent` untouched) or #116 (`bindings.js` untouched — byte-identical to `main`).

## Tests

`npx jest`: 19 suites, 720 passed, 1 skipped, 0 failures (baseline on `main` is 714). `npm run lint` clean.

Every hunk mutation-tested — reverted, confirmed a specific test fails, restored. Two notes worth recording:

- The minimum length for the enhanced handler is **29**, not 27 as I first assumed: the binding read is `readUInt8(28)`, not the earlier `readUInt16LE(26)`. Derived from the reads and confirmed by mutation with a 28-byte buffer.
- The first attempt at the length-check mutation was invisible, because an all-zero short buffer hit the pre-existing all-zero guard before reaching the reads. The checked-in tests use non-zero payloads so the mutation is actually observable — worth knowing if you touch those tests.

`git diff -w main -- lib/hci-socket/hci.js` shows exactly the three intended hunks and no change to `onSocketData`.
