### PR TITLE
fix(hci): make extended mode deterministic

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -105,7 +105,8 @@ const Hci = function (options) {
   this._isStarted = false;
   this._isDevUp = null;
   this._devUpPollTimer = null;
-  this._isExtended = 'extended' in options && options.extended;
+  this._extendedModeConfigured = Object.prototype.hasOwnProperty.call(options, 'extended');
+  this._isExtended = this._extendedModeConfigured ? Boolean(options.extended) : false;
   this._state = null;
   this._bindParams = 'bindParams' in options ? options.bindParams : undefined;
   this._handleBuffers = {};
@@ -987,8 +988,10 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
   if (cmd === RESET_CMD) {
     this.afterReset();
   } else if (cmd === LE_READ_LOCAL_SUPPORTED_FEATURES && status === 0) {
-    // Set _isExtended based on leExtendedAdvertising bit (12)
-    this._isExtended = (result[1] & (1 << 4)) !== 0;
+    if (!this._extendedModeConfigured) {
+      // Auto-detect from the LE Extended Advertising feature bit (12).
+      this._isExtended = (result[1] & (1 << 4)) !== 0;
+    }
     this.emit('leFeatures', result);
 
     if (this._isExtended) {
@@ -1043,7 +1046,6 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
       }, num = ${extendedScan ? 'true' : 'false'}`
     );
 
-    this._isExtended = extendedScanParameters && extendedScan;
   } else if (cmd === READ_BD_ADDR_CMD) {
     this.addressType = 'public';
     this.address = result

--- a/test/lib/hci-socket/hci.test.js
+++ b/test/lib/hci-socket/hci.test.js
@@ -77,6 +77,45 @@ describe('hci-socket hci', () => {
     });
   });
 
+  describe('extended mode configuration', () => {
+    it('keeps an explicit true value when capability replies disagree', () => {
+      const configuredHci = new Hci({ extended: true });
+      const noLeExtendedAdvertising = Buffer.alloc(8);
+      const noExtendedScanCommands = Buffer.alloc(64);
+
+      configuredHci.processCmdCompleteEvent(8195, 0, noLeExtendedAdvertising);
+      configuredHci.processCmdCompleteEvent(4098, 0, noExtendedScanCommands);
+
+      should(configuredHci._isExtended).be.true();
+    });
+
+    it('keeps an explicit false value when capabilities advertise extended support', () => {
+      const configuredHci = new Hci({ extended: false });
+      const leExtendedAdvertising = Buffer.alloc(8);
+      const extendedScanCommands = Buffer.alloc(64);
+      leExtendedAdvertising[1] = 0x10;
+      extendedScanCommands[37] = 0x30;
+
+      configuredHci.processCmdCompleteEvent(8195, 0, leExtendedAdvertising);
+      configuredHci.processCmdCompleteEvent(4098, 0, extendedScanCommands);
+
+      should(configuredHci._isExtended).be.false();
+    });
+
+    it('auto-detects from LE features only and always stores a boolean', () => {
+      const detectedHci = new Hci({});
+      const leExtendedAdvertising = Buffer.alloc(8);
+      const noExtendedScanCommands = Buffer.alloc(64);
+      leExtendedAdvertising[1] = 0x10;
+
+      detectedHci.processCmdCompleteEvent(8195, 0, leExtendedAdvertising);
+      detectedHci.processCmdCompleteEvent(4098, 0, noExtendedScanCommands);
+
+      should(detectedHci._isExtended).be.a.Boolean();
+      should(detectedHci._isExtended).be.true();
+    });
+  });
+
   describe('init', () => {
     it('should reset', () => {
       hci.reset = sinon.spy();
@@ -1655,7 +1694,7 @@ describe('hci-socket hci', () => {
       should(hci._isExtended).equal(false);
     });
 
-    it('should change extended - READ_SUPPORTED_COMMANDS_CMD', () => {
+    it('should report extended commands without changing mode - READ_SUPPORTED_COMMANDS_CMD', () => {
       const cmd = 4098;
       const status = 0;
       const result = Buffer.from([1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20, 21, 22, 23, 24, 25, 26, 27, 28, 28, 30, 31, 32, 33, 34, 35, 35, 36, 0xff]);
@@ -1683,7 +1722,7 @@ describe('hci-socket hci', () => {
 
       // hci checks
       should(hci._aclBuffers).deepEqual(aclBuffers);
-      should(hci._isExtended).equal(32);
+      should(hci._isExtended).equal(false);
     });
 
     it('should emit addressChange - READ_BD_ADDR_CMD', () => {


### PR DESCRIPTION
Fixes #114.

## What changed

- treat an explicit `extended: true` or `extended: false` option as authoritative
- auto-detect extended mode only when the caller did not configure it
- use the existing LE Extended Advertising feature bit as the single auto-detection source
- keep `Read Local Supported Commands` as capability logging instead of a second, arrival-order-dependent writer
- always store a boolean in `_isExtended`

## Why

`_isExtended` was overwritten by two independent command-completion paths. The supported-commands path also assigned `0` or `32` rather than a boolean. In practice Noble does not issue `Read Local Supported Commands` during initialization, while the LE-features path is the existing effective auto-detection behavior, so retaining that source is the smallest compatible fix.

## Impact

Explicit configuration is now stable, and command-completion arrival order can no longer switch Noble between legacy and extended scan/connect commands.

## Validation

- `npx jest --runInBand --coverage=false test/lib/hci-socket/hci.test.js` (119 passed)
- `npm run lint`
