### PR TITLE
fix(hci): guard malformed command completions

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -1012,6 +1012,11 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
     debug(`\t\t\tle = ${le}`);
     debug(`\t\t\tsimul = ${simul}`);
   } else if (cmd === READ_LOCAL_VERSION_CMD) {
+    if (status !== 0 || result.length < 8) {
+      debug(`read local version failed or returned a short result - status: ${status}, length: ${result.length}`);
+      return;
+    }
+
     const hciVer = result.readUInt8(0);
     const hciRev = result.readUInt16LE(1);
     const lmpVer = result.readInt8(3);
@@ -1037,6 +1042,11 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
       lmpSubVer
     );
   } else if (cmd === READ_SUPPORTED_COMMANDS_CMD) {
+    if (status !== 0 || result.length < 38) {
+      debug(`read supported commands failed or returned a short result - status: ${status}, length: ${result.length}`);
+      return;
+    }
+
     const extendedScanParameters = result.readUInt8(37) & 0x10; // LE Set Extended Scan Parameters (Octet 37 - Bit 5)
     const extendedScan = result.readUInt8(37) & 0x20; // LE Set Extended Scan Enable (Octet 37 - Bit 6)
 
@@ -1047,6 +1057,11 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
     );
 
   } else if (cmd === READ_BD_ADDR_CMD) {
+    if (status !== 0 || result.length < 6) {
+      debug(`read bd addr failed or returned a short result - status: ${status}, length: ${result.length}`);
+      return;
+    }
+
     this.addressType = 'public';
     this.address = result
       .toString('hex')

--- a/test/lib/hci-socket/hci.test.js
+++ b/test/lib/hci-socket/hci.test.js
@@ -1452,6 +1452,30 @@ describe('hci-socket hci', () => {
       hci.on('readLocalVersion', readLocalVersionCallback);
     });
 
+    it.each([
+      ['READ_LOCAL_VERSION_CMD', 4097],
+      ['READ_SUPPORTED_COMMANDS_CMD', 4098],
+      ['READ_BD_ADDR_CMD', 4105]
+    ])('does not read absent return parameters after a failed %s', (_name, cmd) => {
+      expect(() => hci.processCmdCompleteEvent(cmd, 0x0c, Buffer.alloc(0))).not.toThrow();
+
+      assert.notCalled(stateChangeCallback);
+      assert.notCalled(addressChangeCallback);
+      assert.notCalled(readLocalVersionCallback);
+    });
+
+    it.each([
+      ['READ_LOCAL_VERSION_CMD', 4097, 8],
+      ['READ_SUPPORTED_COMMANDS_CMD', 4098, 38],
+      ['READ_BD_ADDR_CMD', 4105, 6]
+    ])('does not read a truncated successful %s reply', (_name, cmd, minimumLength) => {
+      expect(() => hci.processCmdCompleteEvent(cmd, 0, Buffer.alloc(minimumLength - 1))).not.toThrow();
+
+      assert.notCalled(stateChangeCallback);
+      assert.notCalled(addressChangeCallback);
+      assert.notCalled(readLocalVersionCallback);
+    });
+
     it('should do nothing', () => {
       const cmd = 0;
       const status = 0;


### PR DESCRIPTION
Fixes #115.

## What changed

Validate both command status and minimum return-parameter length before parsing:

- `Read Local Version Information` (8 bytes)
- `Read Local Supported Commands` (38 bytes for the field Noble reads)
- `Read BD_ADDR` (6 bytes)

Invalid replies are ignored after a debug message and do not mutate HCI state or emit success events.

## Why

A failed Command Complete has no return parameters, and a malformed successful reply can also be shorter than the fields Noble reads. Both cases previously threw synchronously from the socket data handler and could terminate the process.

## Impact

Controller initialization degrades without a process crash when these replies fail or are truncated. Successful replies retain their existing behavior.

## Validation

- `npx jest --runInBand --coverage=false test/lib/hci-socket/hci.test.js` (122 passed)
- `npm run lint`
