### PR TITLE
fix(hci): fail connects when adapter is unavailable

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -111,6 +111,12 @@ NobleBindings.prototype.stopScanning = function () {
 };
 
 NobleBindings.prototype.connect = function (peripheralUuid, parameters = {}) {
+  if (this._state !== 'poweredOn') {
+    const state = this._state || 'unknown';
+    this.emit('connect', peripheralUuid, new Error(`Cannot connect while adapter state is ${state} (not poweredOn)`));
+    return;
+  }
+
   let address = this._addresses[peripheralUuid];
   let addressType = this._addresseTypes[peripheralUuid] || 'random';
   
@@ -182,8 +188,11 @@ NobleBindings.prototype.onStateChange = function (state) {
     return;
   }
 
-  // If we are powered on and we are powered off, disconnect all connections
-  if (this._state === 'poweredOn' && state === 'poweredOff') {
+  const previousState = this._state;
+  this._state = state;
+
+  // Tear down live and queued work whenever the adapter leaves poweredOn.
+  if (previousState === 'poweredOn' && state !== 'poweredOn') {
     for (const handle of Object.keys(this._aclStreams)) {
       this.onDisconnComplete(handle, 0x03); // Hardware Failure
     }
@@ -191,8 +200,6 @@ NobleBindings.prototype.onStateChange = function (state) {
     this._connectionQueue = [];
     this._pendingConnectionUuid = null;
   }
-
-  this._state = state;
 
   if (state === 'unauthorized') {
     console.log(

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -100,7 +100,7 @@ class Noble extends NobleEventEmitter {
         // To unblock the async connect call
         this._onConnect(peripheral.id, new Error('cleanup'));
       }
-      else if (peripheral.state !== 'disconnected') {
+      else if (peripheral.state === 'connected' || peripheral.state === 'disconnecting') {
         this._onDisconnect(peripheral.id, 'cleanup');
       }
     };
@@ -127,8 +127,8 @@ class Noble extends NobleEventEmitter {
   _onStateChange (state) {
     debug(`stateChange ${state}`);
 
-    // If the state is poweredOff and the previous state was poweredOn, clean up the peripherals
-    if (state === 'poweredOff' && this._state === 'poweredOn') {
+    // Any transition away from poweredOn invalidates live and pending work.
+    if (state !== 'poweredOn' && this._state === 'poweredOn') {
       this._cleanupPeriperals();
     }
 

--- a/test/lib/hci-socket/bindings.test.js
+++ b/test/lib/hci-socket/bindings.test.js
@@ -229,6 +229,25 @@ describe('hci-socket bindings', () => {
   });
 
   describe('connect', () => {
+    beforeEach(() => {
+      bindings._state = 'poweredOn';
+    });
+
+    it('rejects while the adapter is not poweredOn without queueing or writing', () => {
+      const connectCallback = jest.fn();
+      bindings._state = 'poweredOff';
+      bindings._hci.createLeConn = jest.fn();
+      bindings.on('connect', connectCallback);
+
+      bindings.connect('112233445566');
+
+      expect(connectCallback).toHaveBeenCalledWith('112233445566', expect.objectContaining({
+        message: expect.stringContaining('poweredOff')
+      }));
+      should(bindings._connectionQueue).be.empty();
+      expect(bindings._hci.createLeConn).not.toHaveBeenCalled();
+    });
+
     it('missing peripheral, no queue, public address', () => {
       bindings._hci.createLeConn = jest.fn();
 
@@ -633,6 +652,29 @@ describe('hci-socket bindings', () => {
       expect(disconnectCallback).toHaveBeenCalledTimes(1);
       expect(disconnectCallback).toHaveBeenCalledWith(uuid, 0x03);
     });
+
+    it.each(['poweredOff', 'unauthorized', 'unsupported'])('clears queued attempts when leaving poweredOn for %s', (state) => {
+      bindings._state = 'poweredOn';
+      bindings._connectionQueue = [{ id: 'pending' }, { id: 'queued' }];
+      bindings._pendingConnectionUuid = 'pending';
+      jest.spyOn(console, 'log').mockImplementation(() => {});
+
+      bindings.onStateChange(state);
+
+      should(bindings._connectionQueue).be.empty();
+      should(bindings._pendingConnectionUuid).equal(null);
+    });
+
+    it('sets the unavailable state before notifying listeners, so a synchronous retry cannot write', () => {
+      bindings._state = 'poweredOn';
+      bindings._hci.createLeConn = jest.fn();
+      bindings.on('stateChange', () => bindings.connect('112233445566'));
+
+      bindings.onStateChange('poweredOff');
+
+      expect(bindings._hci.createLeConn).not.toHaveBeenCalled();
+      should(bindings._connectionQueue).be.empty();
+    });
   });
 
   it('onAddressChange', () => {
@@ -850,6 +892,10 @@ describe('hci-socket bindings', () => {
   });
 
   describe('onLeConnComplete', () => {
+    beforeEach(() => {
+      bindings._state = 'poweredOn';
+    });
+
     it('not on master node', () => {
       const status = 1;
       const handle = 'handle';

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -503,6 +503,15 @@ describe('noble', () => {
     expect(callback).toHaveBeenCalledTimes(1);
   });
 
+  test.each(['poweredOff', 'unauthorized', 'unsupported'])('should clean up when leaving poweredOn for %s', (state) => {
+    const cleanup = jest.spyOn(noble, '_cleanupPeriperals').mockImplementation(() => {});
+    noble._state = 'poweredOn';
+
+    noble._onStateChange(state);
+
+    expect(cleanup).toHaveBeenCalledTimes(1);
+  });
+
   describe('waitForPoweredOnAsync', () => {
     test('should resolve when state changes to poweredOn', async () => {
       // Set initial state to something other than poweredOn
@@ -1185,6 +1194,20 @@ describe('noble', () => {
       
       // Verify peripheral state was updated
       expect(peripheral.state).toBe('disconnected');
+    });
+
+    test('should not emit disconnect while cleaning up a failed connection', () => {
+      const peripheral = {
+        id: 'failed-peripheral',
+        state: 'error',
+        emit: jest.fn()
+      };
+      noble._peripherals.set(peripheral.id, peripheral);
+
+      noble._cleanupPeriperals(peripheral.id);
+
+      expect(peripheral.emit).not.toHaveBeenCalledWith('disconnect', expect.anything());
+      expect(noble._peripherals.has(peripheral.id)).toBe(false);
     });
   });
 


### PR DESCRIPTION
Fixes #119. Completes the adapter-teardown half of #112; #112 should stay open until #116 and this PR have both landed.

## What changed

- reject `connect()` immediately unless the HCI binding is `poweredOn`
- clear the queued and in-flight connection state whenever the adapter leaves `poweredOn`, including `poweredOff`, `unauthorized`, and `unsupported`
- set the binding state before teardown callbacks run, so a synchronous retry cannot write to an unavailable socket
- make Noble clean up pending/live peripherals on every transition away from `poweredOn`
- avoid emitting a fake `disconnect` while removing a peripheral whose connection already failed

## Why

A connect issued before the adapter was ready could become a queue head that never completed, permanently blocking every later connect. The same latch occurred when an active adapter transitioned to `unauthorized` or `unsupported`, because teardown only handled `poweredOff`.

The ordering and cleanup changes are required for safe failure delivery: callbacks may retry synchronously, and a failed (never connected) peripheral must not produce a disconnect event during cleanup.

## Impact

Connecting while the adapter is unavailable now fails fast instead of hanging. This is an intentional public behavior change; the error includes the current adapter state.

## Validation

- `npx jest --runInBand --coverage=false` (19 suites, 723 passed, 1 skipped)
- `npm run lint`
