### PR TITLE
fix(noble): coalesce duplicate connects

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -120,6 +120,10 @@ NobleBindings.prototype.connect = function (peripheralUuid, parameters = {}) {
     return;
   }
 
+  if (this._connectionQueue.some(connection => connection.id === peripheralUuid)) {
+    return;
+  }
+
   let address = this._addresses[peripheralUuid];
   let addressType = this._addresseTypes[peripheralUuid] || 'random';
   

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -390,6 +390,18 @@ class Noble extends NobleEventEmitter {
   connect (idOrAddress, parameters, callback) {
     // Get the identifier for the peripheral
     const identifier = this._getPeripheralId(idOrAddress);
+    const peripheral = this._peripherals.get(identifier);
+
+    if (peripheral && peripheral.state === 'connected') {
+      const error = new Error('Peripheral already connected');
+      if (typeof callback === 'function') {
+        callback(error, peripheral);
+      } else {
+        peripheral.emit('connect', error);
+      }
+      return;
+    }
+
     // Check if callback is a function
     if (typeof callback === 'function') {
       // Add a one-time listener for this specific event

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -45,7 +45,7 @@ class Peripheral extends NobleEventEmitter {
 
     if (this.state === 'connected') {
       this.emit('connect', new Error('Peripheral already connected'));
-    } else {
+    } else if (this.state !== 'connecting') {
       this.state = 'connecting';
       this._noble.connect(this.id, options);
     }

--- a/test/lib/hci-socket/bindings.test.js
+++ b/test/lib/hci-socket/bindings.test.js
@@ -251,6 +251,17 @@ describe('hci-socket bindings', () => {
       expect(bindings._hci.createLeConn).not.toHaveBeenCalled();
     });
 
+    it('coalesces duplicate requests for the same peripheral', () => {
+      bindings._hci.createLeConn = jest.fn();
+
+      bindings.connect('112233445566', { mtu: 100 });
+      bindings.connect('112233445566', { mtu: 200 });
+
+      should(bindings._connectionQueue).have.length(1);
+      should(bindings._connectionQueue[0].params).deepEqual({ mtu: 100 });
+      expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
+    });
+
     it('missing peripheral, no queue, public address', () => {
       bindings._hci.createLeConn = jest.fn();
 

--- a/test/lib/peripheral.test.js
+++ b/test/lib/peripheral.test.js
@@ -125,6 +125,20 @@ describe('peripheral', () => {
       expect(mockNoble.connect).toHaveBeenCalledWith(mockId, options);
       expect(mockNoble.connect).toHaveBeenCalledTimes(1);
     });
+
+    test('coalesces a second call while already connecting', () => {
+      const firstCallback = jest.fn();
+      const secondCallback = jest.fn();
+
+      peripheral.connect(firstCallback);
+      peripheral.connect(secondCallback);
+
+      expect(mockNoble.connect).toHaveBeenCalledTimes(1);
+
+      peripheral.emit('connect');
+      expect(firstCallback).not.toHaveBeenCalled();
+      expect(secondCallback).toHaveBeenCalledWith(undefined);
+    });
   });
 
   describe('connectAsync', () => {

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -352,6 +352,21 @@ describe('noble', () => {
       );
       expect(mockBindings.connect).toHaveBeenCalledTimes(1);
     });
+
+    test('rejects a direct connect for an already connected peripheral without changing its state', () => {
+      const callback = jest.fn();
+      const peripheral = { id: 'peripheral-uuid', state: 'connected', emit: jest.fn() };
+      noble._peripherals.set(peripheral.id, peripheral);
+      mockBindings.addressToId.mockReturnValue(peripheral.id);
+
+      noble.connect(peripheral.id, {}, callback);
+
+      expect(callback).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'Peripheral already connected'
+      }), peripheral);
+      expect(mockBindings.connect).not.toHaveBeenCalled();
+      expect(peripheral.state).toBe('connected');
+    });
   });
 
   describe('onConnect', () => {


### PR DESCRIPTION
Fixes #120.

## What changed

- coalesce duplicate HCI queue entries by peripheral id, retaining the original attempt and its parameters
- make a second `Peripheral.connect()` while `connecting` attach to the existing completion instead of delegating another request
- reject direct `Noble.connect()` calls for an already connected peripheral without invoking the binding or changing the live peripheral's state

## Why

The HCI binding previously queued the same peripheral more than once. After the first attempt succeeded, the duplicate attempt commonly failed with `ACL Connection Already Exists`; Noble then applied that failure to the already-live peripheral and changed its state to `error`.

`Peripheral.connect()` and direct `Noble.connect()` also had different guards, so the protection needs to exist at both the public API and binding queue layers.

## Impact

Only one HCI create-connection operation and one completion event are produced for duplicate in-flight requests. As elsewhere in the current API, `onceExclusive` means the latest callback registered for the same connect event owns that completion.

## Validation

- `npx jest --runInBand --coverage=false` (19 suites, 717 passed, 1 skipped)
- `npm run lint`
