### PR TITLE
fix(hci): match connection completions to attempts

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -20,6 +20,7 @@ const NobleBindings = function (options) {
   this.scannable = {};
 
   this._pendingConnectionUuid = null;
+  this._pendingConnectionAddress = null;
   this._connectionQueue = [];
 
   this._handles = {};
@@ -148,6 +149,7 @@ NobleBindings.prototype.processConnectionQueue = function () {
 
   const nextConn = this._connectionQueue[0];
   this._pendingConnectionUuid = nextConn.id;
+  this._pendingConnectionAddress = this.addressToId(nextConn.address);
   this._hci.createLeConn(nextConn.address, nextConn.addressType, nextConn.params, Object.keys(this._handles).length === 0);
 };
 
@@ -163,6 +165,7 @@ NobleBindings.prototype.cancelConnect = function (peripheralUuid) {
 
   if (this._pendingConnectionUuid === peripheralUuid) {
     this._pendingConnectionUuid = null;
+    this._pendingConnectionAddress = null;
   }
 
   this._hci.cancelConnect(this._handles[peripheralUuid]);
@@ -199,6 +202,7 @@ NobleBindings.prototype.onStateChange = function (state) {
 
     this._connectionQueue = [];
     this._pendingConnectionUuid = null;
+    this._pendingConnectionAddress = null;
   }
 
   if (state === 'unauthorized') {
@@ -309,7 +313,8 @@ NobleBindings.prototype.onLeConnComplete = function (
   interval,
   latency,
   supervisionTimeout,
-  masterClockAccuracy
+  masterClockAccuracy,
+  peerResolvablePrivateAddress
 ) {
   if (role !== 0 && role !== undefined) {
     // not master, ignore
@@ -318,6 +323,16 @@ NobleBindings.prototype.onLeConnComplete = function (
 
   let uuid = null;
   let error = null;
+  const currentConn = this._connectionQueue[0];
+  const completionAddresses = [address, peerResolvablePrivateAddress]
+    .filter((candidate) => typeof candidate === 'string')
+    .map((candidate) => this.addressToId(candidate));
+  const matchesPendingConnection = Boolean(
+    currentConn &&
+    this._pendingConnectionUuid === currentConn.id &&
+    this._pendingConnectionAddress &&
+    completionAddresses.includes(this._pendingConnectionAddress)
+  );
 
   if (status === 0) {
     uuid = this.addressToId(address);
@@ -355,7 +370,7 @@ NobleBindings.prototype.onLeConnComplete = function (
       addressType,
       address
     );
-    const connectionParams = this._connectionQueue.length > 0 ? this._connectionQueue[0].params : {};
+    const connectionParams = matchesPendingConnection ? currentConn.params : {};
     const gatt = new Gatt(address, aclStream, connectionParams && connectionParams.mtu);
     const signaling = new Signaling(handle, aclStream);
 
@@ -408,22 +423,24 @@ NobleBindings.prototype.onLeConnComplete = function (
 
     this._gatts[handle].exchangeMtu();
   } else {
-    const currentConn = this._connectionQueue[0];
-    uuid = currentConn ? currentConn.id : null;
     let statusMessage = Hci.STATUS_MAPPER[status] || 'HCI Error: Unknown';
     const errorCode = ` (0x${status.toString(16)})`;
     statusMessage = statusMessage + errorCode;
     error = new Error(statusMessage);
   }
 
-  // Remove the completed/failed connection attempt from queue
-  this._connectionQueue.shift();
-  this._pendingConnectionUuid = null;
-
-  this.emit('connect', uuid, error);
-
-  // Process next connection in queue if any
-  this.processConnectionQueue();
+  if (matchesPendingConnection) {
+    uuid = currentConn.id;
+    this._connectionQueue.shift();
+    this._pendingConnectionUuid = null;
+    this._pendingConnectionAddress = null;
+    this.emit('connect', uuid, error);
+    this.processConnectionQueue();
+  } else if (status === 0) {
+    // Preserve the existing behavior of adopting unsolicited successful links,
+    // without letting them consume or inherit parameters from a pending attempt.
+    this.emit('connect', uuid, null);
+  }
 };
 
 NobleBindings.prototype.onLeConnUpdateComplete = function (

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -1242,7 +1242,8 @@ Hci.prototype.processLeEnhancedConnComplete = function (status, data) {
     interval,
     latency,
     supervisionTimeout,
-    masterClockAccuracy
+    masterClockAccuracy,
+    peerResolvablePrivateAddress
   );
 };
 

--- a/test/lib/hci-socket/bindings.test.js
+++ b/test/lib/hci-socket/bindings.test.js
@@ -119,6 +119,7 @@ describe('hci-socket bindings', () => {
     should(bindings.scannable).deepEqual({});
 
     should(bindings._pendingConnectionUuid).eql(null);
+    should(bindings._pendingConnectionAddress).eql(null);
     should(bindings._connectionQueue).deepEqual([]);
 
     should(bindings._handles).deepEqual({});
@@ -967,7 +968,9 @@ describe('hci-socket bindings', () => {
 
       const connectCallback = jest.fn();
 
-      bindings._connectionQueue.push({ id: 'pending_uuid' });
+      bindings._connectionQueue.push({ id: 'pending_uuid', address });
+      bindings._pendingConnectionUuid = 'pending_uuid';
+      bindings._pendingConnectionAddress = bindings.addressToId(address);
       bindings.on('connect', connectCallback);
       bindings.onLeConnComplete(status, handle, role, addressType, address);
 
@@ -992,7 +995,9 @@ describe('hci-socket bindings', () => {
 
       const connectCallback = jest.fn();
 
-      bindings._connectionQueue.push({ id: 'pending_uuid' });
+      bindings._connectionQueue.push({ id: 'pending_uuid', address });
+      bindings._pendingConnectionUuid = 'pending_uuid';
+      bindings._pendingConnectionAddress = bindings.addressToId(address);
       bindings.on('connect', connectCallback);
       bindings.onLeConnComplete(status, handle, role, addressType, address);
 
@@ -1016,11 +1021,98 @@ describe('hci-socket bindings', () => {
       const addressType = 'random';
       const address = 'address:split:by:separator';
 
-      bindings._connectionQueue.push({ id: 'pending_uuid', params: { mtu: 100 } });
+      bindings._connectionQueue.push({ id: 'pending_uuid', address, params: { mtu: 100 } });
+      bindings._pendingConnectionUuid = 'pending_uuid';
+      bindings._pendingConnectionAddress = bindings.addressToId(address);
       bindings.onLeConnComplete(status, handle, role, addressType, address);
 
       expect(Gatt).toHaveBeenCalledWith(address, expect.anything(), 100);
       should(bindings._connectionQueue).length(0);
+    });
+
+    it('does not consume the in-flight attempt when a foreign connection completes', () => {
+      bindings._hci.createLeConn = jest.fn();
+      bindings._addresses = { pending_uuid: '11:22:33:44:55:66' };
+      bindings._addresseTypes = { pending_uuid: 'random' };
+      bindings.connect('pending_uuid', { mtu: 100 });
+
+      const connectCallback = jest.fn();
+      bindings.on('connect', connectCallback);
+
+      bindings.onLeConnComplete(0, 'foreign-handle', 0, 'random', 'aa:bb:cc:dd:ee:ff');
+
+      should(bindings._connectionQueue).length(1);
+      should(bindings._pendingConnectionUuid).equal('pending_uuid');
+      should(bindings._pendingConnectionAddress).equal('112233445566');
+      expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
+      expect(Gatt).toHaveBeenCalledWith('aa:bb:cc:dd:ee:ff', expect.anything(), undefined);
+      expect(connectCallback).toHaveBeenCalledWith('aabbccddeeff', null);
+    });
+
+    it('does not consume a queued entry when no connection attempt is in flight', () => {
+      bindings._connectionQueue.push({
+        id: 'pending_uuid',
+        address: '11:22:33:44:55:66',
+        addressType: 'random',
+        params: { mtu: 100 }
+      });
+
+      const connectCallback = jest.fn();
+      bindings.on('connect', connectCallback);
+
+      bindings.onLeConnComplete(0, 'foreign-handle', 0, 'random', '11:22:33:44:55:66');
+
+      should(bindings._connectionQueue).length(1);
+      should(bindings._pendingConnectionUuid).equal(null);
+      should(bindings._pendingConnectionAddress).equal(null);
+      expect(Gatt).toHaveBeenCalledWith('11:22:33:44:55:66', expect.anything(), undefined);
+      expect(connectCallback).toHaveBeenCalledWith('112233445566', null);
+    });
+
+    it('matches an enhanced completion by its peer resolvable private address', () => {
+      bindings._hci.createLeConn = jest.fn();
+      bindings._addresses = { pending_uuid: 'aa:bb:cc:dd:ee:ff' };
+      bindings._addresseTypes = { pending_uuid: 'random' };
+      bindings.connect('pending_uuid', { mtu: 100 });
+
+      const connectCallback = jest.fn();
+      bindings.on('connect', connectCallback);
+
+      bindings.onLeConnComplete(
+        0,
+        'handle',
+        0,
+        'random',
+        '11:22:33:44:55:66',
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        'aa:bb:cc:dd:ee:ff'
+      );
+
+      should(bindings._connectionQueue).length(0);
+      should(bindings._pendingConnectionUuid).equal(null);
+      should(bindings._pendingConnectionAddress).equal(null);
+      expect(Gatt).toHaveBeenCalledWith('11:22:33:44:55:66', expect.anything(), 100);
+      expect(connectCallback).toHaveBeenCalledWith('pending_uuid', null);
+    });
+
+    it('does not fail the in-flight attempt for an unrelated failed completion', () => {
+      bindings._hci.createLeConn = jest.fn();
+      bindings._addresses = { pending_uuid: '11:22:33:44:55:66' };
+      bindings._addresseTypes = { pending_uuid: 'random' };
+      bindings.connect('pending_uuid');
+
+      const connectCallback = jest.fn();
+      bindings.on('connect', connectCallback);
+
+      bindings.onLeConnComplete(0x02, undefined, 0, 'random', 'aa:bb:cc:dd:ee:ff');
+
+      should(bindings._connectionQueue).length(1);
+      should(bindings._pendingConnectionUuid).equal('pending_uuid');
+      should(bindings._pendingConnectionAddress).equal('112233445566');
+      expect(connectCallback).not.toHaveBeenCalled();
     });
 
     it('with connection queue', () => {
@@ -1041,7 +1133,7 @@ describe('hci-socket bindings', () => {
       bindings.onLeConnComplete(status, handle, role, addressType, address);
 
       expect(connectCallback).toHaveBeenCalledTimes(1);
-      expect(connectCallback).toHaveBeenCalledWith('112233445566', null);
+      expect(connectCallback).toHaveBeenCalledWith('queuedId_1', null);
       expect(Hci.createLeConnSpy).toHaveBeenCalledTimes(2);
       expect(Hci.createLeConnSpy).toHaveBeenCalledWith('112233445566', 'random', { addressType: 'random' }, true);
       expect(Hci.createLeConnSpy).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false);
@@ -1070,7 +1162,7 @@ describe('hci-socket bindings', () => {
       bindings.onLeConnComplete(status, handle, role, addressType, address);
 
       expect(connectCallback).toHaveBeenCalledTimes(1);
-      expect(connectCallback).toHaveBeenCalledWith('112233445566', null);
+      expect(connectCallback).toHaveBeenCalledWith('queuedId_1', null);
       expect(Hci.createLeConnSpy).toHaveBeenCalledTimes(2);
       expect(Hci.createLeConnSpy).toHaveBeenCalledWith('112233445566', 'random', { addressType: 'random' }, true);
       expect(Hci.createLeConnSpy).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false);
@@ -1105,8 +1197,8 @@ describe('hci-socket bindings', () => {
 
       expect(connectCallback).toHaveBeenCalledTimes(2);
       
-      expect(connectCallback).toHaveBeenCalledWith('112233445566', null);
-      expect(connectCallback).toHaveBeenCalledWith('998877665544', null);
+      expect(connectCallback).toHaveBeenCalledWith('queuedId_1', null);
+      expect(connectCallback).toHaveBeenCalledWith('queuedId_2', null);
 
       expect(Hci.createLeConnSpy).toHaveBeenCalledTimes(3);
       expect(Hci.createLeConnSpy).toHaveBeenCalledWith('112233445566', 'random', { addressType: 'random' }, true);

--- a/test/lib/hci-socket/hci.test.js
+++ b/test/lib/hci-socket/hci.test.js
@@ -2121,7 +2121,7 @@ describe('hci-socket hci', () => {
     hci.on('leConnComplete', callback);
     hci.processLeEnhancedConnComplete(status, data);
 
-    assert.calledOnceWithExactly(callback, status, 4404, 4, 'random', 'ff:ee:dd:cc:bb:aa', 5138.75, 4625, 51390, 21);
+    assert.calledOnceWithExactly(callback, status, 4404, 4, 'random', 'ff:ee:dd:cc:bb:aa', 5138.75, 4625, 51390, 21, '0e:0d:0c:0b:0a:09');
     should(hci._aclConnections).keys(4404);
     should(hci._aclConnections.get(4404)).deepEqual({ pending: 0 });
   });
@@ -2170,7 +2170,7 @@ describe('hci-socket hci', () => {
     hci.on('leConnComplete', callback);
     hci.processLeEnhancedConnComplete(status, data);
 
-    assert.calledOnceWithExactly(callback, status, 4404, 4, 'random', 'ff:ee:dd:cc:bb:aa', 5138.75, 4625, 51390, 21);
+    assert.calledOnceWithExactly(callback, status, 4404, 4, 'random', 'ff:ee:dd:cc:bb:aa', 5138.75, 4625, 51390, 21, '0e:0d:0c:0b:0a:09');
     should(hci._aclConnections.size).equal(0);
   });
 


### PR DESCRIPTION
### Summary

- track the normalized address of the connection attempt actually in flight
- mutate the queue only when a completion matches that attempt
- preserve unsolicited successful-link adoption without borrowing pending MTU parameters
- expose the peer RPA from Enhanced Connection Complete for identity/RPA matching

### Root cause

`onLeConnComplete` unconditionally used and removed `_connectionQueue[0]`, even when the event belonged to another process or a stale controller operation.

### Validation

- `npm test -- --runInBand` — 19 suites passed, 729 tests passed, 1 skipped
- `npm run lint`

Fixes #118.

The remaining all-zero cancellation behavior from #117 stays separate and will be handled after this identity gate lands.