### PR TITLE
fix(hci): resolve failed connection attempts

### DIFF
--- a/lib/hci-socket/bindings.js
+++ b/lib/hci-socket/bindings.js
@@ -21,6 +21,8 @@ const NobleBindings = function (options) {
 
   this._pendingConnectionUuid = null;
   this._pendingConnectionAddress = null;
+  this._pendingConnectionToken = null;
+  this._cancelledConnectionUuid = null;
   this._connectionQueue = [];
 
   this._handles = {};
@@ -148,9 +150,11 @@ NobleBindings.prototype.processConnectionQueue = function () {
   }
 
   const nextConn = this._connectionQueue[0];
+  const attemptToken = {};
   this._pendingConnectionUuid = nextConn.id;
   this._pendingConnectionAddress = this.addressToId(nextConn.address);
-  this._hci.createLeConn(nextConn.address, nextConn.addressType, nextConn.params, Object.keys(this._handles).length === 0);
+  this._pendingConnectionToken = attemptToken;
+  this._hci.createLeConn(nextConn.address, nextConn.addressType, nextConn.params, Object.keys(this._handles).length === 0, attemptToken);
 };
 
 NobleBindings.prototype.disconnect = function (peripheralUuid) {
@@ -164,8 +168,7 @@ NobleBindings.prototype.cancelConnect = function (peripheralUuid) {
   );
 
   if (this._pendingConnectionUuid === peripheralUuid) {
-    this._pendingConnectionUuid = null;
-    this._pendingConnectionAddress = null;
+    this._cancelledConnectionUuid = peripheralUuid;
   }
 
   this._hci.cancelConnect(this._handles[peripheralUuid]);
@@ -203,6 +206,8 @@ NobleBindings.prototype.onStateChange = function (state) {
     this._connectionQueue = [];
     this._pendingConnectionUuid = null;
     this._pendingConnectionAddress = null;
+    this._pendingConnectionToken = null;
+    this._cancelledConnectionUuid = null;
   }
 
   if (state === 'unauthorized') {
@@ -314,7 +319,8 @@ NobleBindings.prototype.onLeConnComplete = function (
   latency,
   supervisionTimeout,
   masterClockAccuracy,
-  peerResolvablePrivateAddress
+  peerResolvablePrivateAddress,
+  attemptToken
 ) {
   if (role !== 0 && role !== undefined) {
     // not master, ignore
@@ -327,11 +333,21 @@ NobleBindings.prototype.onLeConnComplete = function (
   const completionAddresses = [address, peerResolvablePrivateAddress]
     .filter((candidate) => typeof candidate === 'string')
     .map((candidate) => this.addressToId(candidate));
+  const matchesPendingAttempt = Boolean(
+    this._pendingConnectionUuid &&
+    ((attemptToken && attemptToken === this._pendingConnectionToken) ||
+      (this._pendingConnectionAddress &&
+        completionAddresses.includes(this._pendingConnectionAddress)))
+  );
   const matchesPendingConnection = Boolean(
+    matchesPendingAttempt &&
     currentConn &&
-    this._pendingConnectionUuid === currentConn.id &&
-    this._pendingConnectionAddress &&
-    completionAddresses.includes(this._pendingConnectionAddress)
+    this._pendingConnectionUuid === currentConn.id
+  );
+  const matchesCancelledConnection = Boolean(
+    matchesPendingAttempt &&
+    this._cancelledConnectionUuid &&
+    this._pendingConnectionUuid === this._cancelledConnectionUuid
   );
 
   if (status === 0) {
@@ -429,11 +445,21 @@ NobleBindings.prototype.onLeConnComplete = function (
     error = new Error(statusMessage);
   }
 
-  if (matchesPendingConnection) {
+  if (matchesCancelledConnection) {
+    this._pendingConnectionUuid = null;
+    this._pendingConnectionAddress = null;
+    this._pendingConnectionToken = null;
+    this._cancelledConnectionUuid = null;
+    if (status === 0) {
+      this._hci.disconnect(handle);
+    }
+    this.processConnectionQueue();
+  } else if (matchesPendingConnection) {
     uuid = currentConn.id;
     this._connectionQueue.shift();
     this._pendingConnectionUuid = null;
     this._pendingConnectionAddress = null;
+    this._pendingConnectionToken = null;
     this.emit('connect', uuid, error);
     this.processConnectionQueue();
   } else if (status === 0) {

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -137,6 +137,7 @@ const Hci = function (options) {
 
   this._aclConnections = new Map();
   this._aclQueue = [];
+  this._pendingLeConn = null;
 
   this._deviceId = options.deviceId != null
     ? parseInt(options.deviceId, 10)
@@ -330,6 +331,7 @@ Hci.prototype.stop = function () {
 
   this._aclConnections.clear();
   this._aclQueue = [];
+  this._pendingLeConn = null;
 };
 
 Hci.prototype.readSupportedCommands = function () {
@@ -551,17 +553,17 @@ Hci.prototype.setScanEnabled = function (enabled, filterDuplicates) {
 // Issues related to this:
 // https://github.com/stoprocent/noble/issues/12
 // https://github.com/bluez/bluez/issues/1178
-Hci.prototype.createLeConn = function (address, addressType, parameters = {}, reset = true) {
+Hci.prototype.createLeConn = function (address, addressType, parameters = {}, reset = true, attemptToken) {
   if (reset) {
-    this.once('reset', () => this.createLeConnAfterReset(address, addressType, parameters));
+    this.once('reset', () => this.createLeConnAfterReset(address, addressType, parameters, attemptToken));
     this.reset();
   }
   else {
-    this.createLeConnAfterReset(address, addressType, parameters);
+    this.createLeConnAfterReset(address, addressType, parameters, attemptToken);
   }
 };
 
-Hci.prototype.createLeConnAfterReset = function (address, addressType, parameters = {}) {
+Hci.prototype.createLeConnAfterReset = function (address, addressType, parameters = {}, attemptToken) {
   const {
     minInterval = 0x0006,
     maxInterval = 0x0012,
@@ -633,6 +635,7 @@ Hci.prototype.createLeConnAfterReset = function (address, addressType, parameter
   }
 
   debug(`create le conn - writing: ${cmd.toString('hex')}`);
+  this._pendingLeConn = { address, addressType, token: attemptToken };
   this._socket.write(cmd);
 };
 
@@ -1135,7 +1138,8 @@ Hci.prototype.processLeConnComplete = function (status, data) {
     console.warn(`processLeConnComplete: Caught illegal packet (too short: ${data.length} < 17)`);
     return;
   }
-  if (data.every(byte => byte === 0)) {
+  const allZero = data.every(byte => byte === 0);
+  if (status === 0 && allZero) {
     return;
   }
   const handle = data.readUInt16LE(0);
@@ -1165,8 +1169,18 @@ Hci.prototype.processLeConnComplete = function (status, data) {
     this._aclConnections.set(handle, { pending: 0 });
   }
 
-  this.emit(
-    'leConnComplete',
+  const normalizedAddress = address.replace(/:/g, '').toLowerCase();
+  const pendingAddress = this._pendingLeConn && this._pendingLeConn.address.replace(/:/g, '').toLowerCase();
+  const matchesPendingAttempt = Boolean(
+    this._pendingLeConn &&
+    (normalizedAddress === pendingAddress || (status !== 0 && allZero))
+  );
+  const attemptToken = matchesPendingAttempt ? this._pendingLeConn.token : undefined;
+  if (matchesPendingAttempt) {
+    this._pendingLeConn = null;
+  }
+
+  const eventArguments = [
     status,
     handle,
     role,
@@ -1176,7 +1190,11 @@ Hci.prototype.processLeConnComplete = function (status, data) {
     latency,
     supervisionTimeout,
     masterClockAccuracy
-  );
+  ];
+  if (attemptToken !== undefined) {
+    eventArguments.push(undefined, attemptToken);
+  }
+  this.emit('leConnComplete', ...eventArguments);
 };
 
 Hci.prototype.processLeEnhancedConnComplete = function (status, data) {
@@ -1184,7 +1202,8 @@ Hci.prototype.processLeEnhancedConnComplete = function (status, data) {
     console.warn(`processLeEnhancedConnComplete: Caught illegal packet (too short: ${data.length} < 29)`);
     return;
   }
-  if (data.every(byte => byte === 0)) {
+  const allZero = data.every(byte => byte === 0);
+  if (status === 0 && allZero) {
     return;
   }
   const handle = data.readUInt16LE(0);
@@ -1232,8 +1251,19 @@ Hci.prototype.processLeEnhancedConnComplete = function (status, data) {
     this._aclConnections.set(handle, { pending: 0 });
   }
 
-  this.emit(
-    'leConnComplete',
+  const normalizedAddresses = [address, peerResolvablePrivateAddress]
+    .map((candidate) => candidate.replace(/:/g, '').toLowerCase());
+  const pendingAddress = this._pendingLeConn && this._pendingLeConn.address.replace(/:/g, '').toLowerCase();
+  const matchesPendingAttempt = Boolean(
+    this._pendingLeConn &&
+    (normalizedAddresses.includes(pendingAddress) || (status !== 0 && allZero))
+  );
+  const attemptToken = matchesPendingAttempt ? this._pendingLeConn.token : undefined;
+  if (matchesPendingAttempt) {
+    this._pendingLeConn = null;
+  }
+
+  const eventArguments = [
     status,
     handle,
     role,
@@ -1244,7 +1274,11 @@ Hci.prototype.processLeEnhancedConnComplete = function (status, data) {
     supervisionTimeout,
     masterClockAccuracy,
     peerResolvablePrivateAddress
-  );
+  ];
+  if (attemptToken !== undefined) {
+    eventArguments.push(attemptToken);
+  }
+  this.emit('leConnComplete', ...eventArguments);
 };
 
 Hci.prototype.processLeAdvertisingReport = function (numReports, data) {
@@ -1396,20 +1430,26 @@ Hci.prototype.processLeConnUpdateComplete = function (status, data) {
 Hci.prototype.processCmdStatusEvent = function (cmd, status) {
   if (cmd === LE_CREATE_CONN_CMD || cmd === LE_CREATE_EXTENDED_CONN_CMD) {
     if (status !== 0) {
-      // No LE Connection Complete follows a failed Command Status, and on a shared raw socket
-      // this status may not belong to a command this instance issued, so nothing else is known.
-      this.emit(
-        'leConnComplete',
+      const pendingLeConn = this._pendingLeConn;
+      this._pendingLeConn = null;
+      // No LE Connection Complete follows a failed Command Status. Carry the
+      // identity and private token recorded when this instance wrote the command;
+      // bindings will ignore failures that have no matching local attempt.
+      const eventArguments = [
         status,
         undefined,
         undefined,
-        undefined,
-        undefined,
+        pendingLeConn && pendingLeConn.addressType,
+        pendingLeConn && pendingLeConn.address,
         undefined,
         undefined,
         undefined,
         undefined
-      );
+      ];
+      if (pendingLeConn && pendingLeConn.token !== undefined) {
+        eventArguments.push(undefined, pendingLeConn.token);
+      }
+      this.emit('leConnComplete', ...eventArguments);
     }
   }
 };
@@ -1419,6 +1459,7 @@ Hci.prototype.onStateChange = function (state) {
   if (this._state === 'poweredOn' && state === 'poweredOff') {
     this._aclConnections.clear();
     this._aclQueue = [];
+    this._pendingLeConn = null;
   }
   this._state = state;
 };

--- a/test/lib/hci-socket/bindings.test.js
+++ b/test/lib/hci-socket/bindings.test.js
@@ -120,6 +120,8 @@ describe('hci-socket bindings', () => {
 
     should(bindings._pendingConnectionUuid).eql(null);
     should(bindings._pendingConnectionAddress).eql(null);
+    should(bindings._pendingConnectionToken).eql(null);
+    should(bindings._cancelledConnectionUuid).eql(null);
     should(bindings._connectionQueue).deepEqual([]);
 
     should(bindings._handles).deepEqual({});
@@ -259,7 +261,7 @@ describe('hci-socket bindings', () => {
       should(bindings._connectionQueue[0].params).eql({ addressType: 'public' });
 
       expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
-      expect(bindings._hci.createLeConn).toHaveBeenCalledWith('11:22:33:44:55:66', 'public', { addressType: 'public' }, true);
+      expect(bindings._hci.createLeConn).toHaveBeenCalledWith('11:22:33:44:55:66', 'public', { addressType: 'public' }, true, expect.anything());
     });
 
     it('missing peripheral, no queue, random address', () => {
@@ -272,7 +274,7 @@ describe('hci-socket bindings', () => {
       should(bindings._connectionQueue[0].params).eql({ addressType: 'random' });
 
       expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
-      expect(bindings._hci.createLeConn).toHaveBeenCalledWith('f3:22:33:44:55:66', 'random', { addressType: 'random' }, true);
+      expect(bindings._hci.createLeConn).toHaveBeenCalledWith('f3:22:33:44:55:66', 'random', { addressType: 'random' }, true, expect.anything());
     });
 
     it('existing peripheral, no queue', () => {
@@ -291,7 +293,7 @@ describe('hci-socket bindings', () => {
       should(bindings._connectionQueue[0].params).eql('parameters');
 
       expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
-      expect(bindings._hci.createLeConn).toHaveBeenCalledWith('address', 'addressType', 'parameters', true);
+      expect(bindings._hci.createLeConn).toHaveBeenCalledWith('address', 'addressType', 'parameters', true, expect.anything());
     });
 
     it('missing peripheral, with queue', () => {
@@ -323,7 +325,7 @@ describe('hci-socket bindings', () => {
       bindings.onLeConnComplete(0, 'handle-a', 0, 'random', '11:22:33:44:55:66');
 
       expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(2);
-      expect(bindings._hci.createLeConn).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false);
+      expect(bindings._hci.createLeConn).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false, expect.anything());
     });
 
     describe('regression: concurrent connects during a scan (issue #112)', () => {
@@ -345,12 +347,12 @@ describe('hci-socket bindings', () => {
         bindings.onScanStop();
 
         expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
-        expect(bindings._hci.createLeConn).toHaveBeenCalledWith('112233445566', 'random', { addressType: 'random' }, true);
+        expect(bindings._hci.createLeConn).toHaveBeenCalledWith('112233445566', 'random', { addressType: 'random' }, true, expect.anything());
 
         bindings.onLeConnComplete(0, 'handle-a', 0, 'random', '11:22:33:44:55:66');
 
         expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(2);
-        expect(bindings._hci.createLeConn).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false);
+        expect(bindings._hci.createLeConn).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false, expect.anything());
       });
 
       it('does not strand the queue when scanning resumes (via startScanning/onScanStart) before the second entry starts', () => {
@@ -383,7 +385,7 @@ describe('hci-socket bindings', () => {
 
         expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(2);
         // peripheralA's handle is now registered (its leConnComplete already succeeded), so reset is false.
-        expect(bindings._hci.createLeConn).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false);
+        expect(bindings._hci.createLeConn).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false, expect.anything());
       });
     });
   });
@@ -439,6 +441,56 @@ describe('hci-socket bindings', () => {
 
       expect(bindings._hci.cancelConnect).toHaveBeenCalledTimes(1);
       expect(bindings._hci.cancelConnect).toHaveBeenCalledWith('handle');
+    });
+
+    it('waits for the cancelled attempt completion before starting the next peer', () => {
+      bindings._hci.createLeConn = jest.fn();
+      bindings._hci.cancelConnect = jest.fn();
+      bindings._state = 'poweredOn';
+      bindings._addresses = {
+        peripheralA: '11:22:33:44:55:66',
+        peripheralB: '99:88:77:66:55:44'
+      };
+      bindings._addresseTypes = { peripheralA: 'random', peripheralB: 'public' };
+
+      bindings.connect('peripheralA');
+      bindings.connect('peripheralB');
+      const cancelledToken = bindings._pendingConnectionToken;
+
+      bindings.cancelConnect('peripheralA');
+
+      expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
+      should(bindings._connectionQueue).length(1);
+      should(bindings._pendingConnectionUuid).equal('peripheralA');
+      should(bindings._cancelledConnectionUuid).equal('peripheralA');
+
+      const connectCallback = jest.fn();
+      bindings.on('connect', connectCallback);
+      bindings.onLeConnComplete(
+        0x02,
+        0,
+        0,
+        'public',
+        '00:00:00:00:00:00',
+        0,
+        0,
+        0,
+        0,
+        undefined,
+        cancelledToken
+      );
+
+      expect(connectCallback).not.toHaveBeenCalled();
+      expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(2);
+      expect(bindings._hci.createLeConn).toHaveBeenLastCalledWith(
+        '99:88:77:66:55:44',
+        'public',
+        {},
+        true,
+        expect.anything()
+      );
+      should(bindings._pendingConnectionUuid).equal('peripheralB');
+      should(bindings._cancelledConnectionUuid).equal(null);
     });
   });
 
@@ -573,7 +625,7 @@ describe('hci-socket bindings', () => {
       bindings.connect('peripheralUuid', {});
 
       expect(bindings._hci.createLeConn).toHaveBeenCalledTimes(1);
-      expect(bindings._hci.createLeConn).toHaveBeenCalledWith('bb:bb:bb:bb:bb:bb', 'random', {}, true);
+      expect(bindings._hci.createLeConn).toHaveBeenCalledWith('bb:bb:bb:bb:bb:bb', 'random', {}, true, expect.anything());
     });
 
     it('poweredOn -> poweredOff disconnects all live connections exactly once without throwing', () => {
@@ -1135,8 +1187,8 @@ describe('hci-socket bindings', () => {
       expect(connectCallback).toHaveBeenCalledTimes(1);
       expect(connectCallback).toHaveBeenCalledWith('queuedId_1', null);
       expect(Hci.createLeConnSpy).toHaveBeenCalledTimes(2);
-      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('112233445566', 'random', { addressType: 'random' }, true);
-      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false);
+      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('112233445566', 'random', { addressType: 'random' }, true, expect.anything());
+      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false, expect.anything());
 
       should(bindings._connectionQueue).length(1);
     });
@@ -1164,8 +1216,8 @@ describe('hci-socket bindings', () => {
       expect(connectCallback).toHaveBeenCalledTimes(1);
       expect(connectCallback).toHaveBeenCalledWith('queuedId_1', null);
       expect(Hci.createLeConnSpy).toHaveBeenCalledTimes(2);
-      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('112233445566', 'random', { addressType: 'random' }, true);
-      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false);
+      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('112233445566', 'random', { addressType: 'random' }, true, expect.anything());
+      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false, expect.anything());
       expect(bindings._connectionQueue).toHaveLength(2);
     });
 
@@ -1201,9 +1253,9 @@ describe('hci-socket bindings', () => {
       expect(connectCallback).toHaveBeenCalledWith('queuedId_2', null);
 
       expect(Hci.createLeConnSpy).toHaveBeenCalledTimes(3);
-      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('112233445566', 'random', { addressType: 'random' }, true);
-      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false);
-      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('aabbccddeeff', 'random', { addressType: 'random' }, false);
+      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('112233445566', 'random', { addressType: 'random' }, true, expect.anything());
+      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('998877665544', 'public', { addressType: 'public' }, false, expect.anything());
+      expect(Hci.createLeConnSpy).toHaveBeenCalledWith('aabbccddeeff', 'random', { addressType: 'random' }, false, expect.anything());
       expect(bindings._connectionQueue).toHaveLength(1);
     });
   });

--- a/test/lib/hci-socket/hci.test.js
+++ b/test/lib/hci-socket/hci.test.js
@@ -422,7 +422,7 @@ describe('hci-socket hci', () => {
       hci.createLeConn(address, addressType, parameters, true);
 
       assert.notCalled(hci._socket.write);
-      assert.calledOnceWithExactly(hci.createLeConnAfterReset, address, addressType, parameters);
+      assert.calledOnceWithExactly(hci.createLeConnAfterReset, address, addressType, parameters, undefined);
     });
 
     it('should resume writing the reset command once the ACL connections are gone', () => {
@@ -603,13 +603,14 @@ describe('hci-socket hci', () => {
       const address = 'aa:bb:cc:dd:ee:ff';
       const addressType = 'random';
       const parameters = { minInterval: 0x0060, maxInterval: 0x00c0 };
+      const attemptToken = {};
       
       hci.createLeConnAfterReset = jest.fn();      
-      hci.createLeConn(address, addressType, parameters);
+      hci.createLeConn(address, addressType, parameters, true, attemptToken);
       hci.emit('reset');
 
       expect(hci.createLeConnAfterReset).toHaveBeenCalledWith(
-        address, addressType, parameters
+        address, addressType, parameters, attemptToken
       );
     });
   });
@@ -2138,6 +2139,37 @@ describe('hci-socket hci', () => {
     should(hci._aclConnections.size).equal(0);
   });
 
+  it('emits a non-zero-status all-zero connection completion with its attempt token', () => {
+    const status = 0x02;
+    const data = Buffer.alloc(17);
+    const callback = sinon.spy();
+    const attemptToken = {};
+    hci._pendingLeConn = {
+      address: '11:22:33:44:55:66',
+      addressType: 'random',
+      token: attemptToken
+    };
+
+    hci.on('leConnComplete', callback);
+    hci.processLeConnComplete(status, data);
+
+    assert.calledOnceWithExactly(
+      callback,
+      status,
+      0,
+      0,
+      'public',
+      '00:00:00:00:00:00',
+      0,
+      0,
+      0,
+      0,
+      undefined,
+      attemptToken
+    );
+    should(hci._pendingLeConn).equal(null);
+  });
+
   it('should not emit leConnComplete on processLeEnhancedConnComplete for an all-zero payload (garbage/truncated event guard)', () => {
     const status = 0;
     const data = Buffer.alloc(29);
@@ -2148,6 +2180,37 @@ describe('hci-socket hci', () => {
 
     assert.notCalled(callback);
     should(hci._aclConnections.size).equal(0);
+  });
+
+  it('emits a non-zero-status all-zero enhanced completion with its attempt token', () => {
+    const status = 0x02;
+    const data = Buffer.alloc(29);
+    const callback = sinon.spy();
+    const attemptToken = {};
+    hci._pendingLeConn = {
+      address: '11:22:33:44:55:66',
+      addressType: 'random',
+      token: attemptToken
+    };
+
+    hci.on('leConnComplete', callback);
+    hci.processLeEnhancedConnComplete(status, data);
+
+    assert.calledOnceWithExactly(
+      callback,
+      status,
+      0,
+      0,
+      'public',
+      '00:00:00:00:00:00',
+      0,
+      0,
+      0,
+      0,
+      '00:00:00:00:00:00',
+      attemptToken
+    );
+    should(hci._pendingLeConn).equal(null);
   });
 
   it('should not register an ACL connection when the completion reports a failure status', () => {
@@ -2394,6 +2457,12 @@ describe('hci-socket hci', () => {
 
       it(`should emit event - cmd = ${cmd}`, () => {
         const callback = sinon.spy();
+        const attemptToken = {};
+        hci._pendingLeConn = {
+          address: '11:22:33:44:55:66',
+          addressType: 'random',
+          token: attemptToken
+        };
         hci.on('leConnComplete', callback);
         hci.processCmdStatusEvent(cmd, 'status');
 
@@ -2402,13 +2471,16 @@ describe('hci-socket hci', () => {
           'status',
           undefined,
           undefined,
+          'random',
+          '11:22:33:44:55:66',
           undefined,
           undefined,
           undefined,
           undefined,
           undefined,
-          undefined
+          attemptToken
         );
+        should(hci._pendingLeConn).equal(null);
       });
     });
   });


### PR DESCRIPTION
### Summary

- preserve a private attempt token from the bindings queue through the HCI command write
- attach that token only to matching completions or matching command-status failures
- allow well-formed non-zero all-zero completion payloads through while retaining the successful-garbage guard
- keep a canceled attempt in flight until its own completion, then start the next peer without failing it

### Root cause

Failure events either lacked peer identity or were discarded when their payload was all zero. Relaxing the guard alone was unsafe because queue bookkeeping could then apply a canceled attempt failure to its sibling.

### Validation

- `npm test -- --runInBand` — 19 suites passed, 732 tests passed, 1 skipped
- `npm run lint`

Fixes #117.

Stacked on #126 so the identity gate is reviewed and merged first.