### PR TITLE
fix(hci): stop offering LE Coded PHY for connections by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -746,6 +746,7 @@ The following environment variables can configure noble's behavior:
 |----------|---------|---------|---------|
 | NOBLE_HCI_DEVICE_ID | Specify which HCI adapter to use | 0 | `export NOBLE_HCI_DEVICE_ID=1` |
 | HCI_CHANNEL_USER | Use the exclusive Linux HCI user channel | false | `export HCI_CHANNEL_USER=1` |
+| NOBLE_CODED_PHY | Offer LE Coded PHY for connections (long range, lower throughput; requires controller support) | false | `export NOBLE_CODED_PHY=1` |
 | NOBLE_REPORT_ALL_HCI_EVENTS | Report HCI events without waiting for scan response | false | `export NOBLE_REPORT_ALL_HCI_EVENTS=1` |
 | BLUETOOTH_HCI_SOCKET_UART_PORT | UART port for HCI communication | none | `export BLUETOOTH_HCI_SOCKET_UART_PORT=/dev/ttyUSB0` |
 | BLUETOOTH_HCI_SOCKET_UART_BAUDRATE | UART baudrate | 1000000 | `export BLUETOOTH_HCI_SOCKET_UART_BAUDRATE=1000000` |

--- a/index.d.ts
+++ b/index.d.ts
@@ -274,6 +274,14 @@ declare module '@stoprocent/noble' {
          * channel. The selected adapter must be down before binding.
          */
         userChannel?: boolean;
+        /**
+         * Offer LE Coded PHY as an acceptable PHY for connections, for
+         * long-range links. Off by default: Coded PHY trades throughput for
+         * range, and a peer may negotiate onto it. Ignored on controllers
+         * that do not report the LE Coded PHY feature. Does not affect
+         * scanning.
+         */
+        codedPhy?: boolean;
     }
 
     export interface MacBindingsOptions extends BaseBindingsOptions {}

--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -110,6 +110,10 @@ const Hci = function (options) {
   this._devUpPollTimer = null;
   this._extendedModeConfigured = Object.prototype.hasOwnProperty.call(options, 'extended');
   this._isExtended = this._extendedModeConfigured ? Boolean(options.extended) : false;
+  this._codedPhy = typeof options.codedPhy !== 'undefined'
+    ? Boolean(options.codedPhy)
+    : Boolean(process.env.NOBLE_CODED_PHY);
+  this._supportsCodedPhy = false;
   this._state = null;
   this._bindParams = 'bindParams' in options ? options.bindParams : undefined;
   this._handleBuffers = {};
@@ -322,7 +326,9 @@ Hci.prototype.reset = function () {
 };
 
 Hci.prototype.afterReset = function () {
-  if (this._isExtended) {
+  // HCI_Reset clears the default PHY, so it has to be rewritten here. Support stays false
+  // until the first LE_READ_LOCAL_SUPPORTED_FEATURES reply, so the initial reset writes nothing.
+  if (this._codedPhy && this._supportsCodedPhy) {
     this.setCodedPhySupport();
   }
   this.setEventMask();
@@ -1008,12 +1014,14 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
         // Auto-detect from the LE Extended Advertising feature bit (12).
         this._isExtended = (result[1] & (1 << 4)) !== 0;
       }
+      // LE Coded PHY feature bit (11).
+      this._supportsCodedPhy = (result[1] & (1 << 3)) !== 0;
       this.emit('leFeatures', result);
     } else {
       debug(`le read local supported features failed - status: ${status}`);
     }
 
-    if (this._isExtended) {
+    if (this._codedPhy && this._supportsCodedPhy) {
       this.setCodedPhySupport();
     }
 

--- a/test/lib/hci-socket/hci.test.js
+++ b/test/lib/hci-socket/hci.test.js
@@ -77,6 +77,57 @@ describe('hci-socket hci', () => {
     });
   });
 
+  describe('coded phy configuration', () => {
+    let originalCodedPhy;
+
+    beforeEach(() => {
+      originalCodedPhy = process.env.NOBLE_CODED_PHY;
+    });
+
+    afterEach(() => {
+      if (originalCodedPhy === undefined) {
+        delete process.env.NOBLE_CODED_PHY;
+      } else {
+        process.env.NOBLE_CODED_PHY = originalCodedPhy;
+      }
+    });
+
+    it('is off by default', () => {
+      delete process.env.NOBLE_CODED_PHY;
+
+      should(new Hci({})._codedPhy).be.false();
+    });
+
+    it('treats controller support as unknown until features are read', () => {
+      should(new Hci({ codedPhy: true })._supportsCodedPhy).be.false();
+    });
+
+    it('uses the codedPhy option', () => {
+      delete process.env.NOBLE_CODED_PHY;
+
+      should(new Hci({ codedPhy: true })._codedPhy).be.true();
+    });
+
+    it('allows the option to disable an environment setting', () => {
+      process.env.NOBLE_CODED_PHY = '1';
+
+      should(new Hci({ codedPhy: false })._codedPhy).be.false();
+    });
+
+    it('uses NOBLE_CODED_PHY when the option is omitted', () => {
+      process.env.NOBLE_CODED_PHY = '1';
+
+      should(new Hci({})._codedPhy).be.true();
+    });
+
+    it('is independent of extended mode', () => {
+      delete process.env.NOBLE_CODED_PHY;
+
+      should(new Hci({ extended: true })._codedPhy).be.false();
+      should(new Hci({ codedPhy: true })._isExtended).be.false();
+    });
+  });
+
   describe('extended mode configuration', () => {
     it('keeps an explicit true value when capability replies disagree', () => {
       const configuredHci = new Hci({ extended: true });
@@ -1567,6 +1618,60 @@ describe('hci-socket hci', () => {
   
       expect(hci._isExtended).toBe(false);
     });
+
+    test('should detect extended features without offering coded phy', () => {
+      // result[1] bit 4 is the LE extended advertising feature bit
+      hci.processCmdCompleteEvent(8195, 0, Buffer.from([0x00, 0x10, 0x00, 0x00]));
+
+      expect(hci._isExtended).toBe(true);
+      expect(hci.setCodedPhySupport).not.toHaveBeenCalled();
+    });
+
+    test('should not offer coded phy on a capable controller unless opted in', () => {
+      // result[1] bit 3 is the LE Coded PHY feature bit
+      hci.processCmdCompleteEvent(8195, 0, Buffer.from([0x00, 0x08, 0x00, 0x00]));
+
+      expect(hci._supportsCodedPhy).toBe(true);
+      expect(hci.setCodedPhySupport).not.toHaveBeenCalled();
+    });
+
+    test('should offer coded phy exactly once when opted in and supported', () => {
+      hci._codedPhy = true;
+
+      hci.processCmdCompleteEvent(8195, 0, Buffer.from([0x00, 0x08, 0x00, 0x00]));
+
+      expect(hci._isExtended).toBe(false);
+      expect(hci._supportsCodedPhy).toBe(true);
+      expect(hci.setCodedPhySupport).toHaveBeenCalledTimes(1);
+    });
+
+    test('should not offer coded phy when opted in on an unsupported controller', () => {
+      hci._codedPhy = true;
+
+      hci.processCmdCompleteEvent(8195, 0, Buffer.from([0x00, 0x10, 0x00, 0x00]));
+
+      expect(hci._supportsCodedPhy).toBe(false);
+      expect(hci.setCodedPhySupport).not.toHaveBeenCalled();
+    });
+
+    test('should offer coded phy once at discovery and once per later reset', () => {
+      hci._codedPhy = true;
+
+      hci.processCmdCompleteEvent(8195, 0, Buffer.from([0x00, 0x08, 0x00, 0x00]));
+      expect(hci.setCodedPhySupport).toHaveBeenCalledTimes(1);
+
+      hci.processCmdCompleteEvent(3075, 0, Buffer.from([]));
+      expect(hci.setCodedPhySupport).toHaveBeenCalledTimes(2);
+    });
+
+    test('should not offer coded phy when the feature read fails', () => {
+      hci._codedPhy = true;
+
+      hci.processCmdCompleteEvent(8195, 0x0c, Buffer.from([0x00, 0x08, 0x00, 0x00]));
+
+      expect(hci._supportsCodedPhy).toBe(false);
+      expect(hci.setCodedPhySupport).not.toHaveBeenCalled();
+    });
   });
 
   describe('onSocketError', () => {
@@ -1722,7 +1827,7 @@ describe('hci-socket hci', () => {
       should(hci._isExtended).equal(false);
     });
 
-    it('should reset (extended)', () => {
+    it('should reset (extended) without offering coded phy', () => {
       const cmd = 3075;
       const status = 0;
       const result = Buffer.from([]);
@@ -1735,7 +1840,7 @@ describe('hci-socket hci', () => {
       assert.calledOnceWithExactly(hci.setLeEventMask);
       assert.calledOnceWithExactly(hci.readLocalVersion);
       assert.calledOnceWithExactly(hci.readBdAddr);
-      assert.calledOnceWithExactly(hci.setCodedPhySupport);
+      assert.notCalled(hci.setCodedPhySupport);
 
       // not called
       assert.notCalled(hci.setScanEnabled);
@@ -1751,6 +1856,36 @@ describe('hci-socket hci', () => {
       // hci checks
       should(hci._aclBuffers).deepEqual(aclBuffers);
       should(hci._isExtended).equal(true);
+    });
+
+    it('should reset without offering coded phy before support is known', () => {
+      hci._codedPhy = true;
+
+      hci.processCmdCompleteEvent(3075, 0, Buffer.from([]));
+
+      assert.notCalled(hci.setCodedPhySupport);
+      assert.calledOnceWithExactly(hci.setEventMask);
+      assert.calledOnceWithExactly(hci.setLeEventMask);
+    });
+
+    it('should reapply coded phy on a later reset once support is known', () => {
+      hci._codedPhy = true;
+      hci._supportsCodedPhy = true;
+      hci._isExtended = false;
+
+      hci.processCmdCompleteEvent(3075, 0, Buffer.from([]));
+
+      assert.calledOnceWithExactly(hci.setCodedPhySupport);
+      assert.calledOnceWithExactly(hci.setEventMask);
+      assert.calledOnceWithExactly(hci.setLeEventMask);
+    });
+
+    it('should not reapply coded phy on a later reset when not opted in', () => {
+      hci._supportsCodedPhy = true;
+
+      hci.processCmdCompleteEvent(3075, 0, Buffer.from([]));
+
+      assert.notCalled(hci.setCodedPhySupport);
     });
 
     it('should only log debug - READ_LE_HOST_SUPPORTED_CMD', () => {


### PR DESCRIPTION
Fixes #128. Found while chasing a Matter commissioning failure in matter-js/matterjs-server#929.

## What was happening

`setCodedPhySupport` sends `LE Set Default PHY` offering **LE 1M and LE Coded, omitting LE 2M**, and it was called whenever `_isExtended` was true. `_isExtended` is auto-detected from the extended-advertising feature bit, so every BT5 adapter was told: for all subsequent connections, 1M or Coded are acceptable, 2M is not.

Two separate problems:

1. **Omitting 2M while including Coded** means noble preferred the slowest PHY over the fastest.
2. **`LE Set Default PHY` governs connections, not scanning** (Core Spec Vol 4 Part E §7.8.48). Scanning PHYs come from the `scanning_phys` field of `LE Set Extended Scan Parameters`, which this function never touches. So despite the name and the `_isExtended` gate, its only real effect was on connection throughput — "this adapter supports extended *advertising*" is not a reason to change connection PHY preferences.

## Evidence

`btmon` on an Intel AX201 (`HCI version: Bluetooth 5.2`). noble sends the command twice during init, and there is exactly one PHY update on the live link — 8 ms after Matter's BTP handshake:

```
MainThread[10446]: < ACL Data TX ... ATT: Write Request (0x12) len 11
        Handle: 0x0012 Type: Vendor specific (18ee2ef5-263d-4559-959f-4f9c429f9d11)
          Data[9]: 656c04000000f400ff                              15.379857
> HCI Event: LE Meta Event (0x3e) plen 6
      LE PHY Update Complete (0x0c)
        TX PHY: LE Coded (0x03)   RX PHY: LE Coded (0x03)          15.387736
```

The link drops from 1 Mbps to 125 or 500 kbps. On the application side the accessory answered the 6-byte BTP handshake on Coded but never acknowledged the first 105-byte data packet, and commissioning failed.

Worth noting what the capture does **not** contain: no `LE Set PHY (0x08|0x0032)` anywhere. noble only ever sent the *default* preference, so the PHY change was initiated by the peer — noble's part was permitting Coded and excluding 2M.

## The change

Coded PHY is right for a device at the edge of usable range and wrong for one sitting next to the adapter, so it becomes opt-in rather than being removed:

- `codedPhy` option, or `NOBLE_CODED_PHY` env var, defaulting **off**
- when enabled, the command written is byte-for-byte what it was before
- the option is independent of `extended` in both directions
- extended scanning is untouched

I added the env var because the option is unreachable otherwise for anyone running noble embedded in another application — which is exactly the reporter's situation with matter-server in Docker, where `HCI_CHANNEL_USER` is already set that way. Followed the `userChannel` precedent for the option-beats-env precedence.

## Two things I deliberately did not do

**I did not rename `setCodedPhySupport`.** The name describes an intent the command does not achieve, and I think it is misleading — but it is referenced in 28 places in the test suite, and churning all of them for a cosmetic gain seemed a poor trade against reviewability. Happy to do it as a separate PR if you want; `setDefaultPhy` would be the honest name.

**I did not change the PHY mask.** `0x03` (1M + 2M) would be defensible as a new default, since it actively prefers the fast PHY rather than merely not forbidding it. I left the bytes alone so that the only behavioural change here is *whether* the command is sent, not *what* it says. Say the word if you would rather it were 1M + 2M when opted out.

## Tests

`npx jest`: 19 suites, **792 passed**, 1 skipped, 0 failures (baseline on `main` is 784). `npm run lint` clean.

Both call sites mutation-tested. Worth recording that the first attempt caught me out: reverting the `afterReset` gate failed 2 tests, but reverting the `processCmdCompleteEvent` gate initially failed **none** — the existing tests on that path all leave `_isExtended` false, so the mutation was invisible. Added two tests that drive the LE-features completion with the extended-advertising bit actually set (`result[1] & 0x10`), one asserting Coded is not offered and one asserting it is when opted in. Both mutations now fail 2 tests each.
