### PR TITLE
feat(hci): request LE Data Length Extension for each connection

### DIFF
--- a/lib/hci-socket/hci.js
+++ b/lib/hci-socket/hci.js
@@ -25,6 +25,7 @@ const EVT_LE_ADVERTISING_REPORT = 0x02;
 const EVT_LE_ENHANCED_CONN_COMPLETE = 0x0a;
 const EVT_LE_EXTENDED_ADVERTISING_REPORT = 0x0d;
 const EVT_LE_CONN_UPDATE_COMPLETE = 0x03;
+const EVT_LE_DATA_LENGTH_CHANGE = 0x07;
 
 const OGF_LINK_CTL = 0x01;
 const OCF_DISCONNECT = 0x0006;
@@ -51,6 +52,8 @@ const OCF_LE_READ_BUFFER_SIZE = 0x0002;
 const OCF_LE_READ_LOCAL_SUPPORTED_FEATURES = 0x0003;
 const OCF_LE_SET_EXTENDED_SCAN_PARAMETERS = 0x0041;
 const OCF_LE_SET_EXTENDED_SCAN_ENABLE = 0x0042;
+const OCF_LE_SET_DATA_LENGTH = 0x0022;
+const OCF_LE_READ_MAX_DATA_LENGTH = 0x002f;
 const OCF_LE_SET_SCAN_PARAMETERS = 0x000b;
 const OCF_LE_SET_SCAN_ENABLE = 0x000c;
 const OCF_LE_CREATE_CONN = 0x000d;
@@ -78,6 +81,8 @@ const READ_RSSI_CMD = OCF_READ_RSSI | (OGF_STATUS_PARAM << 10);
 const LE_SET_EVENT_MASK_CMD = OCF_LE_SET_EVENT_MASK | (OGF_LE_CTL << 10);
 const LE_READ_BUFFER_SIZE_CMD = OCF_LE_READ_BUFFER_SIZE | (OGF_LE_CTL << 10);
 const LE_READ_LOCAL_SUPPORTED_FEATURES = OCF_LE_READ_LOCAL_SUPPORTED_FEATURES | (OGF_LE_CTL << 10);
+const LE_SET_DATA_LENGTH_CMD = OCF_LE_SET_DATA_LENGTH | (OGF_LE_CTL << 10);
+const LE_READ_MAX_DATA_LENGTH_CMD = OCF_LE_READ_MAX_DATA_LENGTH | (OGF_LE_CTL << 10);
 const LE_SET_EXTENDED_SCAN_PARAMETERS_CMD =
   OCF_LE_SET_EXTENDED_SCAN_PARAMETERS | (OGF_LE_CTL << 10);
 const LE_SET_EXTENDED_SCAN_ENABLE_CMD =
@@ -94,6 +99,12 @@ const LE_START_ENCRYPTION_CMD = OCF_LE_START_ENCRYPTION | (OGF_LE_CTL << 10);
 
 // Core Spec Vol 6 Part B 2.4: every LE controller supports at least a 27 octet payload
 const LE_MIN_ACL_LENGTH = 27;
+
+// Core Spec Vol 4 Part E 7.8.33: LE Set Data Length parameter ranges
+const LE_MIN_TX_OCTETS = 0x001b;
+const LE_MAX_TX_OCTETS = 0x00fb;
+const LE_MIN_TX_TIME = 0x0148;
+const LE_MAX_TX_TIME = 0x4290;
 const HCI_OE_USER_ENDED_CONNECTION = 0x13;
 
 const STATUS_MAPPER = require('./hci-status');
@@ -114,6 +125,8 @@ const Hci = function (options) {
     ? Boolean(options.codedPhy)
     : Boolean(process.env.NOBLE_CODED_PHY);
   this._supportsCodedPhy = false;
+  this._supportsDataLengthExtension = false;
+  this._maxDataLength = null;
   this._state = null;
   this._bindParams = 'bindParams' in options ? options.bindParams : undefined;
   this._handleBuffers = {};
@@ -410,9 +423,10 @@ Hci.prototype.readBdAddr = function () {
 
 Hci.prototype.setLeEventMask = function () {
   const cmd = Buffer.alloc(12);
+  // Bit 6 is LE Data Length Change; without it the negotiated length is never reported.
   const leEventMask = this._isExtended
-    ? Buffer.from('1fff000000000000', 'hex')
-    : Buffer.from('1f00000000000000', 'hex');
+    ? Buffer.from('5fff000000000000', 'hex')
+    : Buffer.from('5f00000000000000', 'hex');
 
   // header
   cmd.writeUInt8(HCI_COMMAND_PKT, 0);
@@ -453,6 +467,48 @@ Hci.prototype.readLeBufferSize = function () {
 
   debug(`le read buffer size - writing: ${cmd.toString('hex')}`);
   this._socket.write(cmd);
+};
+
+Hci.prototype.readLeMaxDataLength = function () {
+  const cmd = Buffer.alloc(4);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(LE_READ_MAX_DATA_LENGTH_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x0, 3);
+
+  debug(`le read maximum data length - writing: ${cmd.toString('hex')}`);
+  this._socket.write(cmd);
+};
+
+Hci.prototype.setLeDataLength = function (handle) {
+  if (!this._supportsDataLengthExtension || this._maxDataLength === null) {
+    return;
+  }
+
+  const cmd = Buffer.alloc(10);
+
+  // header
+  cmd.writeUInt8(HCI_COMMAND_PKT, 0);
+  cmd.writeUInt16LE(LE_SET_DATA_LENGTH_CMD, 1);
+
+  // length
+  cmd.writeUInt8(0x06, 3);
+
+  // data
+  cmd.writeUInt16LE(handle, 4);
+  cmd.writeUInt16LE(this._maxDataLength.txOctets, 6);
+  cmd.writeUInt16LE(this._maxDataLength.txTime, 8);
+
+  debug(`le set data length - writing: ${cmd.toString('hex')}`);
+  // A link works at the 27 octet default, so a failure here must not fail the connection.
+  try {
+    this._socket.write(cmd);
+  } catch (error) {
+    debug(`le set data length failed - handle: ${handle}, error: ${error.message}`);
+  }
 };
 
 Hci.prototype.readLeHostSupported = function () {
@@ -1016,6 +1072,8 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
       }
       // LE Coded PHY feature bit (11).
       this._supportsCodedPhy = (result[1] & (1 << 3)) !== 0;
+      // LE Data Packet Length Extension feature bit (5).
+      this._supportsDataLengthExtension = (result[0] & (1 << 5)) !== 0;
       this.emit('leFeatures', result);
     } else {
       debug(`le read local supported features failed - status: ${status}`);
@@ -1025,6 +1083,12 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
       this.setCodedPhySupport();
     }
 
+    if (this._supportsDataLengthExtension) {
+      this.readLeMaxDataLength();
+    } else {
+      this._maxDataLength = null;
+    }
+
     this.setEventMask();
     this.setLeEventMask();
     this.readLocalVersion();
@@ -1032,6 +1096,36 @@ Hci.prototype.processCmdCompleteEvent = function (cmd, status, result) {
     this.readLeHostSupported();
     this.readLeBufferSize();
     this.readBdAddr();
+  } else if (cmd === LE_SET_DATA_LENGTH_CMD) {
+    if (status !== 0) {
+      debug(`le set data length failed - status: ${status}`);
+    }
+  } else if (cmd === LE_READ_MAX_DATA_LENGTH_CMD) {
+    if (status !== 0 || result.length < 8) {
+      debug(`le read maximum data length failed or returned a short result - status: ${status}, length: ${result.length}`);
+      return;
+    }
+
+    const txOctets = result.readUInt16LE(0);
+    const txTime = result.readUInt16LE(2);
+    const rxOctets = result.readUInt16LE(4);
+    const rxTime = result.readUInt16LE(6);
+
+    debug(`\t\t\tsupported max tx octets = ${txOctets}`);
+    debug(`\t\t\tsupported max tx time = ${txTime}`);
+    debug(`\t\t\tsupported max rx octets = ${rxOctets}`);
+    debug(`\t\t\tsupported max rx time = ${rxTime}`);
+
+    if (txOctets < LE_MIN_TX_OCTETS || txTime < LE_MIN_TX_TIME) {
+      debug(`le read maximum data length returned values below the spec minimum - octets: ${txOctets}, time: ${txTime}`);
+      this._maxDataLength = null;
+      return;
+    }
+
+    this._maxDataLength = {
+      txOctets: Math.min(txOctets, LE_MAX_TX_OCTETS),
+      txTime: Math.min(txTime, LE_MAX_TX_TIME)
+    };
   } else if (cmd === READ_LE_HOST_SUPPORTED_CMD && status === 0) {
     const le = result.readUInt8(0);
     const simul = result.readUInt8(1);
@@ -1157,7 +1251,32 @@ Hci.prototype.processLeMetaEvent = function (eventType, numReports, data) {
     this.processLeExtendedAdvertisingReport(numReports, data);
   } else if (eventType === EVT_LE_CONN_UPDATE_COMPLETE) {
     this.processLeConnUpdateComplete(numReports, data);
+  } else if (eventType === EVT_LE_DATA_LENGTH_CHANGE) {
+    this.processLeDataLengthChange(numReports, data);
   }
+};
+
+// The caller has already consumed the first parameter octet, which for this subevent is the
+// low byte of the connection handle rather than a status or report count.
+Hci.prototype.processLeDataLengthChange = function (handleLowByte, data) {
+  if (data.length < 9) {
+    debug(`processLeDataLengthChange: ignoring illegal packet (too short: ${data.length} < 9)`);
+    return;
+  }
+
+  const handle = handleLowByte | (data.readUInt8(0) << 8);
+  const maxTxOctets = data.readUInt16LE(1);
+  const maxTxTime = data.readUInt16LE(3);
+  const maxRxOctets = data.readUInt16LE(5);
+  const maxRxTime = data.readUInt16LE(7);
+
+  debug(`\t\t\thandle = ${handle}`);
+  debug(`\t\t\tmax tx octets = ${maxTxOctets}`);
+  debug(`\t\t\tmax tx time = ${maxTxTime}`);
+  debug(`\t\t\tmax rx octets = ${maxRxOctets}`);
+  debug(`\t\t\tmax rx time = ${maxRxTime}`);
+
+  this.emit('leDataLengthChange', handle, maxTxOctets, maxTxTime, maxRxOctets, maxRxTime);
 };
 
 Hci.prototype.processLeConnComplete = function (status, data) {
@@ -1194,6 +1313,7 @@ Hci.prototype.processLeConnComplete = function (status, data) {
 
   if (status === 0) {
     this._aclConnections.set(handle, { pending: 0 });
+    this.setLeDataLength(handle);
   }
 
   const normalizedAddress = address.replace(/:/g, '').toLowerCase();
@@ -1276,6 +1396,7 @@ Hci.prototype.processLeEnhancedConnComplete = function (status, data) {
 
   if (status === 0) {
     this._aclConnections.set(handle, { pending: 0 });
+    this.setLeDataLength(handle);
   }
 
   const normalizedAddresses = [address, peerResolvablePrivateAddress]

--- a/test/lib/hci-socket/hci.test.js
+++ b/test/lib/hci-socket/hci.test.js
@@ -611,13 +611,224 @@ describe('hci-socket hci', () => {
   describe('setLeEventMask', () => {
     it('should setLeEventMask', () => {
       hci.setLeEventMask();
-      assert.calledOnceWithExactly(hci._socket.write, Buffer.from([1, 1, 0x20, 8, 0x1f, 0, 0, 0, 0, 0, 0, 0]));
+      assert.calledOnceWithExactly(hci._socket.write, Buffer.from([1, 1, 0x20, 8, 0x5f, 0, 0, 0, 0, 0, 0, 0]));
     });
 
     it('should setLeEventMask for BLE5 (extended)', () => {
       hci._isExtended = true;
       hci.setLeEventMask();
-      assert.calledOnceWithExactly(hci._socket.write, Buffer.from([1, 1, 0x20, 8, 0x1f, 0xff, 0, 0, 0, 0, 0, 0]));
+      assert.calledOnceWithExactly(hci._socket.write, Buffer.from([1, 1, 0x20, 8, 0x5f, 0xff, 0, 0, 0, 0, 0, 0]));
+    });
+
+    it('should enable the data length change subevent in both modes', () => {
+      hci.setLeEventMask();
+      should(hci._socket.write.firstCall.args[0].readUInt8(4) & 0x40).equal(0x40);
+
+      hci._socket.write.resetHistory();
+      hci._isExtended = true;
+      hci.setLeEventMask();
+      should(hci._socket.write.firstCall.args[0].readUInt8(4) & 0x40).equal(0x40);
+    });
+  });
+
+  describe('data length extension', () => {
+    const LE_READ_LOCAL_SUPPORTED_FEATURES = 0x2003;
+    const LE_READ_MAX_DATA_LENGTH_CMD = 0x202f;
+    const LE_SET_DATA_LENGTH_OPCODE = 0x2022;
+
+    const writesOf = (opcode) => hci._socket.write.getCalls()
+      .map((call) => call.args[0])
+      .filter((buffer) => buffer.length >= 3 && buffer.readUInt16LE(1) === opcode);
+
+    // The address byte keeps the buffer from being all zero, which both handlers discard.
+    const connCompleteData = (handle = 0x0040) => {
+      const data = Buffer.alloc(17);
+      data.writeUInt16LE(handle, 0);
+      data.writeUInt8(0x01, 9);
+      return data;
+    };
+
+    const enhancedConnCompleteData = (handle = 0x0040) => {
+      const data = Buffer.alloc(29);
+      data.writeUInt16LE(handle, 0);
+      data.writeUInt8(0x01, 9);
+      return data;
+    };
+
+    const maxDataLengthResult = (txOctets, txTime, rxOctets = 251, rxTime = 17040) => {
+      const result = Buffer.alloc(8);
+      result.writeUInt16LE(txOctets, 0);
+      result.writeUInt16LE(txTime, 2);
+      result.writeUInt16LE(rxOctets, 4);
+      result.writeUInt16LE(rxTime, 6);
+      return result;
+    };
+
+    const withNegotiatedMax = (txOctets = 251, txTime = 2120) => {
+      hci._supportsDataLengthExtension = true;
+      hci._maxDataLength = { txOctets, txTime };
+    };
+
+    it('treats the controller as unsupported until features are read', () => {
+      should(hci._supportsDataLengthExtension).be.false();
+      should(hci._maxDataLength).be.null();
+    });
+
+    it('reads the controller maximum when the feature bit is set', () => {
+      // result[0] bit 5 is the LE Data Packet Length Extension feature bit
+      hci.processCmdCompleteEvent(LE_READ_LOCAL_SUPPORTED_FEATURES, 0, Buffer.from([0x20, 0x00, 0x00, 0x00]));
+
+      should(hci._supportsDataLengthExtension).be.true();
+      should(writesOf(LE_READ_MAX_DATA_LENGTH_CMD)).have.length(1);
+    });
+
+    it('leaves an unsupported controller alone', () => {
+      hci.processCmdCompleteEvent(LE_READ_LOCAL_SUPPORTED_FEATURES, 0, Buffer.from([0x00, 0x00, 0x00, 0x00]));
+
+      should(hci._supportsDataLengthExtension).be.false();
+      should(writesOf(LE_READ_MAX_DATA_LENGTH_CMD)).be.empty();
+    });
+
+    it('does not read the maximum when the feature read fails', () => {
+      hci.processCmdCompleteEvent(LE_READ_LOCAL_SUPPORTED_FEATURES, 0x0c, Buffer.from([0x20, 0x00, 0x00, 0x00]));
+
+      should(hci._supportsDataLengthExtension).be.false();
+      should(writesOf(LE_READ_MAX_DATA_LENGTH_CMD)).be.empty();
+    });
+
+    it('forgets a stored maximum when a later feature read reports no support', () => {
+      withNegotiatedMax();
+
+      hci.processCmdCompleteEvent(LE_READ_LOCAL_SUPPORTED_FEATURES, 0, Buffer.from([0x00, 0x00, 0x00, 0x00]));
+
+      should(hci._maxDataLength).be.null();
+    });
+
+    it('stores the reported maximum tx octets and time', () => {
+      hci.processCmdCompleteEvent(LE_READ_MAX_DATA_LENGTH_CMD, 0, maxDataLengthResult(251, 2120));
+
+      should(hci._maxDataLength).deepEqual({ txOctets: 251, txTime: 2120 });
+    });
+
+    it('clamps a reported maximum above the spec range', () => {
+      hci.processCmdCompleteEvent(LE_READ_MAX_DATA_LENGTH_CMD, 0, maxDataLengthResult(0xffff, 0xffff));
+
+      should(hci._maxDataLength).deepEqual({ txOctets: 251, txTime: 17040 });
+    });
+
+    it('rejects a reported maximum below the spec range', () => {
+      hci.processCmdCompleteEvent(LE_READ_MAX_DATA_LENGTH_CMD, 0, maxDataLengthResult(26, 2120));
+      should(hci._maxDataLength).be.null();
+
+      hci.processCmdCompleteEvent(LE_READ_MAX_DATA_LENGTH_CMD, 0, maxDataLengthResult(251, 327));
+      should(hci._maxDataLength).be.null();
+    });
+
+    it('ignores a failed maximum read', () => {
+      hci.processCmdCompleteEvent(LE_READ_MAX_DATA_LENGTH_CMD, 0x0c, maxDataLengthResult(251, 2120));
+
+      should(hci._maxDataLength).be.null();
+    });
+
+    it('ignores a short maximum read result', () => {
+      hci.processCmdCompleteEvent(LE_READ_MAX_DATA_LENGTH_CMD, 0, Buffer.from([0xfb, 0x00, 0x48, 0x08]));
+
+      should(hci._maxDataLength).be.null();
+    });
+
+    it('requests the data length once per connection', () => {
+      withNegotiatedMax(251, 2120);
+
+      hci.processLeConnComplete(0, connCompleteData(0x0040));
+
+      const writes = writesOf(LE_SET_DATA_LENGTH_OPCODE);
+      should(writes).have.length(1);
+      should(writes[0]).deepEqual(Buffer.from([1, 0x22, 0x20, 6, 0x40, 0x00, 0xfb, 0x00, 0x48, 0x08]));
+    });
+
+    it('requests the data length for an enhanced connection', () => {
+      withNegotiatedMax(251, 2120);
+
+      hci.processLeEnhancedConnComplete(0, enhancedConnCompleteData(0x0041));
+
+      const writes = writesOf(LE_SET_DATA_LENGTH_OPCODE);
+      should(writes).have.length(1);
+      should(writes[0].readUInt16LE(4)).equal(0x0041);
+    });
+
+    it('requests the data length again on reconnect', () => {
+      withNegotiatedMax();
+
+      hci.processLeConnComplete(0, connCompleteData(0x0040));
+      hci.processLeConnComplete(0, connCompleteData(0x0041));
+
+      should(writesOf(LE_SET_DATA_LENGTH_OPCODE)).have.length(2);
+    });
+
+    it('does not request the data length on an unsupported controller', () => {
+      hci._maxDataLength = { txOctets: 251, txTime: 2120 };
+
+      hci.processLeConnComplete(0, connCompleteData());
+
+      should(writesOf(LE_SET_DATA_LENGTH_OPCODE)).be.empty();
+    });
+
+    it('does not request the data length before the maximum is known', () => {
+      hci._supportsDataLengthExtension = true;
+
+      hci.processLeConnComplete(0, connCompleteData());
+
+      should(writesOf(LE_SET_DATA_LENGTH_OPCODE)).be.empty();
+    });
+
+    it('does not request the data length for a failed connection', () => {
+      withNegotiatedMax();
+
+      hci.processLeConnComplete(0x3e, connCompleteData());
+
+      should(writesOf(LE_SET_DATA_LENGTH_OPCODE)).be.empty();
+    });
+
+    it('still completes the connection when the request cannot be written', () => {
+      withNegotiatedMax();
+      hci._socket.write.throws(new Error('ENOBUFS'));
+      const callback = sinon.spy();
+      hci.on('leConnComplete', callback);
+
+      hci.processLeConnComplete(0, connCompleteData(0x0040));
+
+      assert.calledOnce(callback);
+      should(hci._aclConnections.has(0x0040)).be.true();
+    });
+
+    // Characterization: a rejected request is logged and otherwise ignored, so the stored
+    // controller maximum stays usable for the next connection and no retry is attempted.
+    it('keeps the stored maximum when the controller rejects the request', () => {
+      withNegotiatedMax(251, 2120);
+
+      hci.processCmdCompleteEvent(LE_SET_DATA_LENGTH_OPCODE, 0x11, Buffer.from([0x40, 0x00]));
+
+      should(hci._maxDataLength).deepEqual({ txOctets: 251, txTime: 2120 });
+      should(writesOf(LE_SET_DATA_LENGTH_OPCODE)).be.empty();
+    });
+
+    it('emits the negotiated length from the data length change event', () => {
+      const callback = sinon.spy();
+      hci.on('leDataLengthChange', callback);
+
+      // subevent parameters: handle 0x0140, max tx octets/time, max rx octets/time
+      hci.processLeMetaEvent(0x07, 0x40, Buffer.from([0x01, 0xfb, 0x00, 0x48, 0x08, 0xfb, 0x00, 0x48, 0x08]));
+
+      assert.calledOnceWithExactly(callback, 0x0140, 251, 2120, 251, 2120);
+    });
+
+    it('ignores a short data length change event', () => {
+      const callback = sinon.spy();
+      hci.on('leDataLengthChange', callback);
+
+      hci.processLeMetaEvent(0x07, 0x40, Buffer.from([0x01, 0xfb, 0x00, 0x48]));
+
+      assert.notCalled(callback);
     });
   });
 


### PR DESCRIPTION
Implements the per-connection approach from your triage on #130. Based on current `main` and independent of #129 — it touches `setLeEventMask`, `processCmdCompleteEvent`, both connection-complete handlers and `processLeMetaEvent`, none of which #129 changes, so the two apply in either order.

Against your six points:

1. **Local support** comes from feature bit 5 of `LE Read Local Supported Features` (`result[0] & (1 << 5)`), read only when the reply status is zero. A controller without the bit gets no new command on any path.
2. **`LE Read Maximum Data Length`** is issued only when supported. A nonzero status or a result shorter than 8 octets is logged and leaves the stored maximum unset, without disturbing the rest of the initialization chain. Reported TX octets or time below the spec minimum are rejected outright; values above the maximum are clamped to 251 and 17040, so a controller reporting nonsense cannot produce an out-of-range request. A later feature read that reports no support discards a previously stored maximum.
3. **`LE Set Data Length` per handle**, from both `processLeConnComplete` and `processLeEnhancedConnComplete`, on successful completions only, and only when support and a validated maximum are both known. The socket write is wrapped so a failure cannot prevent `leConnComplete` from being emitted — a link works at the default length, so this must never decide whether a connection succeeds. I did not touch `LE Write Suggested Default Data Length` at all, for the reset reason you gave.
4. **LE Meta subevent 0x07** — one correction to the instruction, please check my reasoning. Bit 6 was missing from *both* masks, not just the basic one. Both began `0x1f`, which is bits 0 to 4, i.e. subevents 0x01 to 0x05. The extended mask's second octet `0xff` covers bits 8 to 15, i.e. subevents 0x09 to 0x10, so it skips bit 6. Both masks are now `0x5f` in the first octet. Empirical confirmation: after that single change the only two failing tests in the whole suite were the two existing mask assertions, one for each mode. Happy to revert half of it if you read the mask differently.
5. **`LE Data Length Change`** is dispatched from `processLeMetaEvent`, length-checked, and emits `leDataLengthChange` with the handle, MaxTxOctets, MaxTxTime, MaxRxOctets and MaxRxTime. One wrinkle worth flagging for review: the generic meta-event dispatch in `onSocketData` has already consumed the subevent's first parameter octet, which for this subevent is the *low byte of the connection handle* rather than a status or report count, so the handler reassembles the handle from that byte plus the high byte at the head of the remaining data. There is a test asserting a handle of `0x0140` specifically to pin that down. The event is emitted on the `Hci` object, at the same level as `leConnUpdateComplete`; say the word if you would rather it reached the public API and I will add that.
6. **Tests** — 21 new plus the two updated mask assertions: capability unknown at construction, feature bit set and clear, feature read failing, stale maximum discarded, maximum parsed, clamped, rejected below range, failed read, short read, exactly one request per connection, request on the enhanced path, request again on reconnect, no request when unsupported, no request before the maximum is known, no request for a failed connection, connection still completes when the write throws, both event masks, negotiated length emitted, short event ignored, and a rejected request characterized.

HCI ACL buffer accounting and fragmentation are untouched, as you asked — controller HCI buffers and Link Layer data length are separate mechanisms and `getAclBuffers`, `writeAclDataPkt` and `flushAcl` are not in the diff.

I checked each production hunk by reverting it and confirming a named test fails, so they are not passing vacuously. One exception I should be explicit about: the branch that logs a nonzero status for `LE Set Data Length` itself is *not* covered — removing it leaves the suite green, because it only calls `debug()` and this suite asserts no debug output anywhere. I kept it for observability rather than dropping a silent failure, but it is unproven and I did not want to claim otherwise.

Local full suite: 19 suites, 805 passed, 1 expected skip. Lint clean.

I have not tested this against real hardware yet. The reporter on the downstream issue that started this work is on a raw-channel Linux setup, so once #129 is in a nightly I can ask for a run with both changes and report the negotiated lengths from `DEBUG=hci`.

Fixes #130
