### PR TITLE
feat(win): Support Windows Bluetooth custom pairing types

### DIFF
--- a/README.md
+++ b/README.md
@@ -391,6 +391,11 @@ peripheral.on('disconnect', reason => {
 ### Pairing
 
 ```typescript
+import noble, {
+  DevicePairingKinds,
+  DevicePairingProtectionLevel,
+} from '@stoprocent/noble';
+
 // Pair at the Noble level (by ID or address) or on a Peripheral instance.
 await noble.pairAsync(idOrAddress);
 // or
@@ -399,8 +404,8 @@ await peripheral.pairAsync();
 // Optionally choose pairing ceremony + protection level (Windows only).
 await noble.pairAsync(
   idOrAddress,
-  noble.DevicePairingKinds.ConfirmOnly,
-  noble.DevicePairingProtectionLevel.EncryptionAndAuthentication
+  DevicePairingKinds.ConfirmOnly,
+  DevicePairingProtectionLevel.EncryptionAndAuthentication
 );
 
 // Callback form is also available on both.
@@ -423,9 +428,12 @@ noble.on('pair', (peripheral, error) => { /* ... */ });
   discovered and connected (present in Noble's peripheral map) before pairing
   is requested. Pairing an unknown/untracked id fails rather than hanging.
 - **Windows pairing options.** `kind` defaults to `ConfirmOnly` and
-  `protectionLevel` defaults to `Encryption`. You can pass any
-  `DevicePairingKinds` bitmask and (optionally) `DevicePairingProtectionLevel`.
-  For non-ConfirmOnly ceremonies, Windows handles the native pairing UX.
+  `protectionLevel` defaults to `Encryption`. You can pass a
+  `DevicePairingKinds` bitmask (single or OR-ed values) and (optionally)
+  `DevicePairingProtectionLevel`.
+  `ConfirmOnly`, `DisplayPin`, and `ConfirmPinMatch` use Windows' native UI;
+  PIN/password kinds (`ProvidePin`, `ProvidePassword`, `ConfirmPassword`) are
+  rejected because this library does not collect secrets to pass into WinRT.
 
 ### Service Methods
 

--- a/README.md
+++ b/README.md
@@ -396,6 +396,13 @@ await noble.pairAsync(idOrAddress);
 // or
 await peripheral.pairAsync();
 
+// Optionally choose pairing ceremony + protection level (Windows only).
+await noble.pairAsync(
+  idOrAddress,
+  noble.DevicePairingKinds.ConfirmOnly,
+  noble.DevicePairingProtectionLevel.EncryptionAndAuthentication
+);
+
 // Callback form is also available on both.
 noble.pair(idOrAddress, error => { /* ... */ });
 peripheral.pair(error => { /* ... */ });
@@ -415,13 +422,10 @@ noble.on('pair', (peripheral, error) => { /* ... */ });
 - **A connected device is required.** The peripheral must already be
   discovered and connected (present in Noble's peripheral map) before pairing
   is requested. Pairing an unknown/untracked id fails rather than hanging.
-- **Only the `ConfirmOnly` ("Just Works") ceremony is supported.** The
-  handler auto-accepts `ConfirmOnly` requests without a UI prompt. Any other
-  ceremony (`DisplayPin`, `ProvidePassword`, `ConfirmPinMatch`, …) is **not**
-  accepted — this library has no UI to surface a PIN or password — and Windows
-  completes the operation with the corresponding failure status
-  (e.g. `RejectedByHandler` / `AuthenticationNotAllowed`), which is reported
-  back through the `pair` callback/event.
+- **Windows pairing options.** `kind` defaults to `ConfirmOnly` and
+  `protectionLevel` defaults to `Encryption`. You can pass any
+  `DevicePairingKinds` bitmask and (optionally) `DevicePairingProtectionLevel`.
+  For non-ConfirmOnly ceremonies, Windows handles the native pairing UX.
 
 ### Service Methods
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -85,13 +85,16 @@ declare module '@stoprocent/noble' {
         stop(): void;
         setAddress(address: string): void;
 
-        /**
-         * Pair with a peripheral. `kind` defaults to
-         * `DevicePairingKinds.ConfirmOnly` and `protectionLevel` defaults to
-         * `DevicePairingProtectionLevel.Encryption`. On Windows, non-ConfirmOnly
-         * kinds (e.g. `DisplayPin`) use the OS pairing dialog. On non-Windows
-         * platforms the call surfaces a "Pairing is not supported" error.
-         */
+     /**
+      * Pair with a peripheral. `kind` defaults to
+      * `DevicePairingKinds.ConfirmOnly` and `protectionLevel` defaults to
+     * `DevicePairingProtectionLevel.Encryption`. On Windows, `ConfirmOnly`,
+     * `DisplayPin`, and `ConfirmPinMatch` use the OS pairing dialog. PIN /
+     * password kinds (`ProvidePin`, `ProvidePassword`, `ConfirmPassword`) are
+     * rejected because this library does not collect secrets to pass into
+     * WinRT. On non-Windows platforms the call surfaces a "Pairing is not
+     * supported" error.
+     */
         pair(idOrAddress: PeripheralIdOrAddress, callback: (error: Error | undefined) => void): void;
         pair(idOrAddress: PeripheralIdOrAddress, kind?: DevicePairingKinds, callback?: (error: Error | undefined) => void): void;
         pair(idOrAddress: PeripheralIdOrAddress, kind: DevicePairingKinds, protectionLevel: DevicePairingProtectionLevel, callback?: (error: Error | undefined) => void): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -25,6 +25,25 @@ declare module '@stoprocent/noble' {
 
     export type CharacteristicProperty = 'read' | 'write' | 'indicate' | 'notify' | 'writeWithoutResponse';
 
+    /**
+     * Mirrors WinRT's `DevicePairingKinds` (Windows.Devices.Enumeration).
+     * Bitfield: pass a single kind or OR several together to advertise
+     * which ceremonies the caller knows how to handle.
+     *
+     * Only the Windows binding honors this; `pair()` on hci-socket / dbus /
+     * mac surfaces "Pairing is not supported on this platform" regardless
+     * of the value.
+     */
+    export enum DevicePairingKinds {
+        None = 0,
+        ConfirmOnly = 0x00000008,
+        DisplayPin = 0x00000010,
+        ConfirmPinMatch = 0x00000020,
+        ProvidePin = 0x00000040,
+        ProvidePassword = 0x00000080,
+        ConfirmPassword = 0x00000100,
+    }
+
     export interface ConnectOptions {
         addressType?: PeripheralAddressType;
         minInterval?: number;
@@ -45,26 +64,25 @@ declare module '@stoprocent/noble' {
         stopScanningAsync(): Promise<void>;
         discoverAsync(): AsyncGenerator<Peripheral, void, unknown>;
         connectAsync(idOrAddress: PeripheralIdOrAddress, options?: ConnectOptions): Promise<Peripheral>;
-        /**
-         * Pair with a peripheral. Windows only; requires an already-connected
-         * peripheral and supports only the ConfirmOnly ("Just Works") ceremony.
-         * Rejects with 'Pairing is not supported on this platform' elsewhere.
-         */
-        pairAsync(idOrAddress: PeripheralIdOrAddress): Promise<void>;
+        pairAsync(idOrAddress: PeripheralIdOrAddress, kind?: DevicePairingKinds): Promise<void>;
 
         startScanning(serviceUUIDs?: string[], allowDuplicates?: boolean, callback?: (error?: Error) => void): void;
         stopScanning(callback?: () => void): void;
         connect(idOrAddress: PeripheralIdOrAddress, options?: ConnectOptions, callback?: (error: Error | undefined, peripheral: Peripheral) => void): void;
-        /**
-         * Pair with a peripheral. Windows only; requires an already-connected
-         * peripheral and supports only the ConfirmOnly ("Just Works") ceremony.
-         * Calls back with 'Pairing is not supported on this platform' elsewhere.
-         */
-        pair(idOrAddress: PeripheralIdOrAddress, callback?: (error: Error | null) => void): void;
         cancelConnect(idOrAddress: PeripheralIdOrAddress, options?: object): void;
         reset(): void;
         stop(): void;
         setAddress(address: string): void;
+
+        /**
+         * Pair with a peripheral. `kind` defaults to
+         * `DevicePairingKinds.ConfirmOnly` (Just Works, no UI). On Windows,
+         * any other kind (e.g. `DisplayPin`) causes Windows to surface its
+         * native pairing dialog — this library does not forward a PIN or
+         * password back to JS. On non-Windows platforms the call surfaces
+         * a "Pairing is not supported" error.
+         */
+        pair(idOrAddress: PeripheralIdOrAddress, kind?: DevicePairingKinds, callback?: (error: Error | undefined) => void): void;
     
         on(event: "stateChange", listener: (state: AdapterState) => void): this;
         on(event: "scanStart", listener: () => void): this;
@@ -119,8 +137,7 @@ declare module '@stoprocent/noble' {
         readonly uuid: string;
     
         connectAsync(): Promise<void>;
-        /** Windows only; ConfirmOnly ("Just Works") ceremony only. */
-        pairAsync(): Promise<void>;
+        pairAsync(kind?: DevicePairingKinds): Promise<void>;
         disconnectAsync(): Promise<void>;
         updateRssiAsync(): Promise<number>;
         discoverServicesAsync(): Promise<Service[]>;
@@ -131,8 +148,7 @@ declare module '@stoprocent/noble' {
         writeHandleAsync(handle: number, data: Buffer, withoutResponse: boolean): Promise<void>;
 
         connect(callback?: (error: Error | undefined) => void): void;
-        /** Windows only; ConfirmOnly ("Just Works") ceremony only. */
-        pair(callback?: (error: Error | null) => void): void;
+        pair(kind?: DevicePairingKinds, callback?: (error: Error | undefined) => void): void;
         disconnect(callback?: () => void): void;
         updateRssi(callback?: (error: Error | undefined, rssi: number) => void): void;
         discoverServices(): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -44,6 +44,17 @@ declare module '@stoprocent/noble' {
         ConfirmPassword = 0x00000100,
     }
 
+    /**
+     * Mirrors WinRT's `DevicePairingProtectionLevel`.
+     * Used only by the Windows binding.
+     */
+    export enum DevicePairingProtectionLevel {
+        Default = 0,
+        None = 1,
+        Encryption = 2,
+        EncryptionAndAuthentication = 3,
+    }
+
     export interface ConnectOptions {
         addressType?: PeripheralAddressType;
         minInterval?: number;
@@ -64,7 +75,7 @@ declare module '@stoprocent/noble' {
         stopScanningAsync(): Promise<void>;
         discoverAsync(): AsyncGenerator<Peripheral, void, unknown>;
         connectAsync(idOrAddress: PeripheralIdOrAddress, options?: ConnectOptions): Promise<Peripheral>;
-        pairAsync(idOrAddress: PeripheralIdOrAddress, kind?: DevicePairingKinds): Promise<void>;
+        pairAsync(idOrAddress: PeripheralIdOrAddress, kind?: DevicePairingKinds, protectionLevel?: DevicePairingProtectionLevel): Promise<void>;
 
         startScanning(serviceUUIDs?: string[], allowDuplicates?: boolean, callback?: (error?: Error) => void): void;
         stopScanning(callback?: () => void): void;
@@ -76,13 +87,14 @@ declare module '@stoprocent/noble' {
 
         /**
          * Pair with a peripheral. `kind` defaults to
-         * `DevicePairingKinds.ConfirmOnly` (Just Works, no UI). On Windows,
-         * any other kind (e.g. `DisplayPin`) causes Windows to surface its
-         * native pairing dialog — this library does not forward a PIN or
-         * password back to JS. On non-Windows platforms the call surfaces
-         * a "Pairing is not supported" error.
+         * `DevicePairingKinds.ConfirmOnly` and `protectionLevel` defaults to
+         * `DevicePairingProtectionLevel.Encryption`. On Windows, non-ConfirmOnly
+         * kinds (e.g. `DisplayPin`) use the OS pairing dialog. On non-Windows
+         * platforms the call surfaces a "Pairing is not supported" error.
          */
+        pair(idOrAddress: PeripheralIdOrAddress, callback: (error: Error | undefined) => void): void;
         pair(idOrAddress: PeripheralIdOrAddress, kind?: DevicePairingKinds, callback?: (error: Error | undefined) => void): void;
+        pair(idOrAddress: PeripheralIdOrAddress, kind: DevicePairingKinds, protectionLevel: DevicePairingProtectionLevel, callback?: (error: Error | undefined) => void): void;
     
         on(event: "stateChange", listener: (state: AdapterState) => void): this;
         on(event: "scanStart", listener: () => void): this;
@@ -137,7 +149,7 @@ declare module '@stoprocent/noble' {
         readonly uuid: string;
     
         connectAsync(): Promise<void>;
-        pairAsync(kind?: DevicePairingKinds): Promise<void>;
+        pairAsync(kind?: DevicePairingKinds, protectionLevel?: DevicePairingProtectionLevel): Promise<void>;
         disconnectAsync(): Promise<void>;
         updateRssiAsync(): Promise<number>;
         discoverServicesAsync(): Promise<Service[]>;
@@ -148,7 +160,9 @@ declare module '@stoprocent/noble' {
         writeHandleAsync(handle: number, data: Buffer, withoutResponse: boolean): Promise<void>;
 
         connect(callback?: (error: Error | undefined) => void): void;
+        pair(callback: (error: Error | undefined) => void): void;
         pair(kind?: DevicePairingKinds, callback?: (error: Error | undefined) => void): void;
+        pair(kind: DevicePairingKinds, protectionLevel: DevicePairingProtectionLevel, callback?: (error: Error | undefined) => void): void;
         disconnect(callback?: () => void): void;
         updateRssi(callback?: (error: Error | undefined, rssi: number) => void): void;
         discoverServices(): void;

--- a/index.js
+++ b/index.js
@@ -1,6 +1,8 @@
 const withBindings = require('./lib/resolve-bindings');
 const hciStatusMessage = require('./lib/hci-status-message');
+const DevicePairingKinds = require('./lib/pairing-kinds');
 
 module.exports = withBindings();
 module.exports.withBindings = withBindings;
 module.exports.hciStatusMessage = hciStatusMessage;
+module.exports.DevicePairingKinds = DevicePairingKinds;

--- a/index.js
+++ b/index.js
@@ -1,8 +1,10 @@
 const withBindings = require('./lib/resolve-bindings');
 const hciStatusMessage = require('./lib/hci-status-message');
 const DevicePairingKinds = require('./lib/pairing-kinds');
+const DevicePairingProtectionLevel = require('./lib/pairing-protection-level');
 
 module.exports = withBindings();
 module.exports.withBindings = withBindings;
 module.exports.hciStatusMessage = hciStatusMessage;
 module.exports.DevicePairingKinds = DevicePairingKinds;
+module.exports.DevicePairingProtectionLevel = DevicePairingProtectionLevel;

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -8,6 +8,7 @@ const Characteristic = require('./characteristic');
 const Descriptor = require('./descriptor');
 const DevicePairingKinds = require('./pairing-kinds');
 const DevicePairingProtectionLevel = require('./pairing-protection-level');
+const isUint32 = require('./uint32');
 
 class Noble extends NobleEventEmitter {
   
@@ -451,6 +452,15 @@ class Noble extends NobleEventEmitter {
       callback = protectionLevel;
       protectionLevel = undefined;
     }
+    if (kind !== undefined && kind !== null && !isUint32(kind)) {
+      const err = new Error('pair() kind must be a finite uint32 DevicePairingKinds bitmask');
+      if (typeof callback === 'function') {
+        callback(err);
+      } else {
+        this.emit('warning', err.message);
+      }
+      return;
+    }
     // Reject an empty mask up-front. Otherwise the native handler's
     // `kind & kinds` would always be 0, causing PairAsync to fail with
     // a generic RejectedByHandler that's indistinguishable from the
@@ -469,8 +479,8 @@ class Noble extends NobleEventEmitter {
       : kind;
     if (protectionLevel !== undefined &&
         protectionLevel !== null &&
-        typeof protectionLevel !== 'number') {
-      const err = new Error('pair() protectionLevel must be a number (DevicePairingProtectionLevel)');
+        !isUint32(protectionLevel)) {
+      const err = new Error('pair() protectionLevel must be a finite uint32 DevicePairingProtectionLevel');
       if (typeof callback === 'function') {
         callback(err);
       } else {

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -7,6 +7,7 @@ const Service = require('./service');
 const Characteristic = require('./characteristic');
 const Descriptor = require('./descriptor');
 const DevicePairingKinds = require('./pairing-kinds');
+const DevicePairingProtectionLevel = require('./pairing-protection-level');
 
 class Noble extends NobleEventEmitter {
   
@@ -434,7 +435,7 @@ class Noble extends NobleEventEmitter {
     }
   }
 
-  pair (idOrAddress, kind, callback) {
+  pair (idOrAddress, kind, protectionLevel, callback) {
     const identifier = this._getPeripheralId(idOrAddress);
 
     // Backward compat: `pair(id, callback)` — the legacy signature passes
@@ -445,6 +446,10 @@ class Noble extends NobleEventEmitter {
     if (typeof kind === 'function') {
       callback = kind;
       kind = undefined;
+      protectionLevel = undefined;
+    } else if (typeof protectionLevel === 'function') {
+      callback = protectionLevel;
+      protectionLevel = undefined;
     }
     // Reject an empty mask up-front. Otherwise the native handler's
     // `kind & kinds` would always be 0, causing PairAsync to fail with
@@ -462,6 +467,20 @@ class Noble extends NobleEventEmitter {
     const pairingKind = (kind === undefined || kind === null)
       ? DevicePairingKinds.ConfirmOnly
       : kind;
+    if (protectionLevel !== undefined &&
+        protectionLevel !== null &&
+        typeof protectionLevel !== 'number') {
+      const err = new Error('pair() protectionLevel must be a number (DevicePairingProtectionLevel)');
+      if (typeof callback === 'function') {
+        callback(err);
+      } else {
+        this.emit('warning', err.message);
+      }
+      return;
+    }
+    const pairingProtectionLevel = (protectionLevel === undefined || protectionLevel === null)
+      ? DevicePairingProtectionLevel.Encryption
+      : protectionLevel;
 
     if (typeof callback === 'function') {
       this.onceExclusive(`pair:${identifier}`, error => callback(error));
@@ -484,12 +503,12 @@ class Noble extends NobleEventEmitter {
       this.emit(`pair:${identifier}`, err);
       return;
     }
-    this._bindings.pair(identifier, pairingKind);
+    this._bindings.pair(identifier, pairingKind, pairingProtectionLevel);
   }
 
-  async pairAsync (idOrAddress, kind) {
+  async pairAsync (idOrAddress, kind, protectionLevel) {
     return new Promise((resolve, reject) => {
-      this.pair(idOrAddress, kind, error => error ? reject(error) : resolve());
+      this.pair(idOrAddress, kind, protectionLevel, error => error ? reject(error) : resolve());
     });
   }
 

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -6,6 +6,7 @@ const Peripheral = require('./peripheral');
 const Service = require('./service');
 const Characteristic = require('./characteristic');
 const Descriptor = require('./descriptor');
+const DevicePairingKinds = require('./pairing-kinds');
 
 class Noble extends NobleEventEmitter {
   
@@ -433,8 +434,35 @@ class Noble extends NobleEventEmitter {
     }
   }
 
-  pair (idOrAddress, callback) {
+  pair (idOrAddress, kind, callback) {
     const identifier = this._getPeripheralId(idOrAddress);
+
+    // Backward compat: `pair(id, callback)` — the legacy signature passes
+    // the callback in the 2nd position. Detect that and default `kind` to
+    // ConfirmOnly so existing callers see no behavior change. The new
+    // signature's `kind` is a number, so a function in this slot is
+    // unambiguously the legacy callback.
+    if (typeof kind === 'function') {
+      callback = kind;
+      kind = undefined;
+    }
+    // Reject an empty mask up-front. Otherwise the native handler's
+    // `kind & kinds` would always be 0, causing PairAsync to fail with
+    // a generic RejectedByHandler that's indistinguishable from the
+    // device refusing a ceremony we asked for.
+    if (kind === 0) {
+      const err = new Error('pair() requires at least one DevicePairingKinds value; DevicePairingKinds.None matches no ceremony');
+      if (typeof callback === 'function') {
+        callback(err);
+      } else {
+        this.emit('warning', err.message);
+      }
+      return;
+    }
+    const pairingKind = (kind === undefined || kind === null)
+      ? DevicePairingKinds.ConfirmOnly
+      : kind;
+
     if (typeof callback === 'function') {
       this.onceExclusive(`pair:${identifier}`, error => callback(error));
     }
@@ -442,7 +470,8 @@ class Noble extends NobleEventEmitter {
       // Only the Windows bindings implement pairing today. Surface a
       // deterministic error via the same event the callback waits on, so
       // callers don't hang waiting for a 'pair' completion that will
-      // never come.
+      // never come. The requested `kind` is ignored on unsupported
+      // platforms.
       const err = new Error('Pairing is not supported on this platform');
       const peripheral = this._peripherals.get(identifier);
       if (peripheral) {
@@ -455,12 +484,12 @@ class Noble extends NobleEventEmitter {
       this.emit(`pair:${identifier}`, err);
       return;
     }
-    this._bindings.pair(identifier);
+    this._bindings.pair(identifier, pairingKind);
   }
 
-  async pairAsync (idOrAddress) {
+  async pairAsync (idOrAddress, kind) {
     return new Promise((resolve, reject) => {
-      this.pair(idOrAddress, error => error ? reject(error) : resolve());
+      this.pair(idOrAddress, kind, error => error ? reject(error) : resolve());
     });
   }
 

--- a/lib/pairing-kinds.js
+++ b/lib/pairing-kinds.js
@@ -1,0 +1,13 @@
+// Integer values mirror WinRT's DevicePairingKinds enum (Windows.Devices.Enumeration).
+// Only the Windows binding uses these; other bindings' `pair()` is a no-op (see
+// noble.js, which surfaces a deterministic "Pairing is not supported on this
+// platform" error for bindings without a `pair` method).
+module.exports = {
+  None:            0,
+  ConfirmOnly:     0x00000008,
+  DisplayPin:      0x00000010,
+  ConfirmPinMatch: 0x00000020,
+  ProvidePin:      0x00000040,
+  ProvidePassword: 0x00000080,
+  ConfirmPassword: 0x00000100,
+};

--- a/lib/pairing-kinds.js
+++ b/lib/pairing-kinds.js
@@ -1,7 +1,6 @@
 // Integer values mirror WinRT's DevicePairingKinds enum (Windows.Devices.Enumeration).
-// Only the Windows binding uses these; other bindings' `pair()` is a no-op (see
-// noble.js, which surfaces a deterministic "Pairing is not supported on this
-// platform" error for bindings without a `pair` method).
+// Only the Windows binding uses these; other bindings surface a deterministic
+// "Pairing is not supported on this platform" error when pairing is requested.
 module.exports = {
   None:            0,
   ConfirmOnly:     0x00000008,

--- a/lib/pairing-protection-level.js
+++ b/lib/pairing-protection-level.js
@@ -1,0 +1,10 @@
+// Integer values mirror WinRT's DevicePairingProtectionLevel enum
+// (Windows.Devices.Enumeration). Only the Windows binding uses these;
+// other bindings' `pair()` surfaces "Pairing is not supported on this
+// platform".
+module.exports = {
+  Default: 0,
+  None: 1,
+  Encryption: 2,
+  EncryptionAndAuthentication: 3,
+};

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -57,7 +57,7 @@ class Peripheral extends NobleEventEmitter {
     });
   }
 
-  pair (kind, callback) {
+  pair (kind, protectionLevel, callback) {
     // Backward compat: `peripheral.pair(callback)` — the legacy signature
     // passes the callback in the 1st position. Detect that and forward
     // `undefined` as the kind so `noble.pair` defaults to ConfirmOnly.
@@ -72,13 +72,17 @@ class Peripheral extends NobleEventEmitter {
     if (typeof kind === 'function') {
       callback = kind;
       kind = undefined;
+      protectionLevel = undefined;
+    } else if (typeof protectionLevel === 'function') {
+      callback = protectionLevel;
+      protectionLevel = undefined;
     }
-    this._noble.pair(this.id, kind, callback);
+    this._noble.pair(this.id, kind, protectionLevel, callback);
   }
 
-  async pairAsync (kind) {
+  async pairAsync (kind, protectionLevel) {
     return new Promise((resolve, reject) => {
-      this.pair(kind, error => error ? reject(error) : resolve());
+      this.pair(kind, protectionLevel, error => error ? reject(error) : resolve());
     });
   }
 

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -57,19 +57,28 @@ class Peripheral extends NobleEventEmitter {
     });
   }
 
-  pair (callback) {
-    // Delegate the callback to Noble#pair so it is released via the internal
-    // pair:${id} event. Noble#_onPair always emits pair:${id} (even when this
-    // peripheral has been removed from Noble's map during cleanup), whereas it
-    // only emits this peripheral's 'pair' event while still tracked. Registering
-    // on the peripheral event would therefore leave the callback hanging if
-    // pairing completes after the peripheral is gone.
-    this._noble.pair(this.id, callback);
+  pair (kind, callback) {
+    // Backward compat: `peripheral.pair(callback)` — the legacy signature
+    // passes the callback in the 1st position. Detect that and forward
+    // `undefined` as the kind so `noble.pair` defaults to ConfirmOnly.
+    //
+    // The callback is delegated to Noble#pair so it is released via the
+    // internal pair:${id} event. Noble#_onPair always emits pair:${id}
+    // (even when this peripheral has been removed from Noble's map during
+    // cleanup), whereas it only emits this peripheral's 'pair' event while
+    // still tracked. Registering on the peripheral event would therefore
+    // leave the callback hanging if pairing completes after the peripheral
+    // is gone.
+    if (typeof kind === 'function') {
+      callback = kind;
+      kind = undefined;
+    }
+    this._noble.pair(this.id, kind, callback);
   }
 
-  async pairAsync () {
+  async pairAsync (kind) {
     return new Promise((resolve, reject) => {
-      this.pair(error => error ? reject(error) : resolve());
+      this.pair(kind, error => error ? reject(error) : resolve());
     });
   }
 

--- a/lib/uint32.js
+++ b/lib/uint32.js
@@ -1,0 +1,5 @@
+const UINT32_MAX = 0xFFFFFFFF;
+
+module.exports = function isUint32 (value) {
+  return Number.isInteger(value) && value >= 0 && value <= UINT32_MAX;
+};

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -435,12 +435,10 @@ bool BLEManager::Pair(const std::string& uuid,
             return true;
         }
 
-        auto unsupportedKinds = static_cast<uint32_t>(
-            winrt::Windows::Devices::Enumeration::DevicePairingKinds::ProvidePin) |
-            static_cast<uint32_t>(
-                winrt::Windows::Devices::Enumeration::DevicePairingKinds::ProvidePassword) |
-            static_cast<uint32_t>(
-                winrt::Windows::Devices::Enumeration::DevicePairingKinds::ConfirmPassword);
+        // These ceremony values are not supported because this library does
+        // not collect PIN/password input to forward into an Accept(...) overload.
+        constexpr uint32_t unsupportedKinds =
+            0x00000040u | 0x00000080u | 0x00000100u;
         if ((static_cast<uint32_t>(kinds) & unsupportedKinds) != 0)
         {
             mEmit.Paired(uuid, false,

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -388,7 +388,7 @@ void BLEManager::OnMaxPduSizeChanged(GattSession session, winrt::Windows::Founda
     mEmit.MTU(uuid, mtu);
 }
 
-bool BLEManager::Pair(const std::string& uuid, DevicePairingKinds kinds)
+bool BLEManager::Pair(const std::string& uuid, winrt::Windows::Devices::Enumeration::DevicePairingKinds kinds)
 {
     auto it = mDeviceMap.find(uuid);
     if (it == mDeviceMap.end() || !it->second.device.has_value())

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -388,10 +388,8 @@ void BLEManager::OnMaxPduSizeChanged(GattSession session, winrt::Windows::Founda
     mEmit.MTU(uuid, mtu);
 }
 
-bool BLEManager::Pair(const std::string& uuid)
+bool BLEManager::Pair(const std::string& uuid, DevicePairingKinds kinds)
 {
-    using winrt::Windows::Devices::Enumeration::DevicePairingKinds;
-
     auto it = mDeviceMap.find(uuid);
     if (it == mDeviceMap.end() || !it->second.device.has_value())
     {
@@ -435,32 +433,35 @@ bool BLEManager::Pair(const std::string& uuid)
             return true;
         }
 
-        // Use custom pairing so we can auto-accept the ConfirmOnly (Just Works)
-        // ceremony without a UI prompt. The actual kind the device requests is
-        // logged so we can diagnose failures.
+        // Always go through `pairing.Custom()`: only DeviceInformationCustomPairing
+        // accepts a `DevicePairingKinds` mask (DeviceInformationPairing.PairAsync
+        // takes only a protection level). The caller-supplied `kinds` is the set
+        // of ceremonies we know how to handle — for ConfirmOnly this is the
+        // Just Works path (no UI); for DisplayPin / ProvidePin / etc. Windows
+        // surfaces its native pairing dialog after we Accept() below.
         //
-        // The PairingRequested handler must Accept() the args exactly once for
-        // ConfirmOnly; for any other kind (DisplayPin / ProvidePassword /
-        // ConfirmPinMatch etc.) we simply return without Accept(), which Windows
-        // treats as a rejection and the PairAsync completes with the appropriate
-        // failure status (RejectedByHandler / AuthenticationNotAllowed). We have
-        // no UI to surface a PIN or password prompt from this library.
+        // The PairingRequested lambda must Accept() exactly once for any kind
+        // the caller advertised in `kinds`. For kinds outside the mask we
+        // return without Accept(), which Windows treats as a rejection and the
+        // PairAsync completes with RejectedByHandler / AuthenticationNotAllowed.
+        // We never forward a PIN or password back to JS — Windows drives the UI
+        // for non-ConfirmOnly ceremonies.
         custom = pairing.Custom();
         token = custom.PairingRequested(
-            [](winrt::Windows::Devices::Enumeration::DeviceInformationCustomPairing const&,
-            winrt::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs const& args) {
+            [kinds](winrt::Windows::Devices::Enumeration::DeviceInformationCustomPairing const&,
+                winrt::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs const& args) {
                 auto kind = args.PairingKind();
                 LOGE("pairing requested, kind=%d", static_cast<int>(kind));
-                if (kind == DevicePairingKinds::ConfirmOnly)
+                if ((static_cast<uint32_t>(kind) & static_cast<uint32_t>(kinds)) != 0)
                 {
                     args.Accept();
                 }
-                // Any other kind: do not call Accept() — Windows treats the
-                // handler returning as a rejection.
+                // Any kind outside the caller's mask: do not call Accept() —
+                // Windows treats the handler returning as a rejection.
             });
         handlerRegistered = true;
         auto completed = bind2(this, &BLEManager::OnPaired, uuid, token, custom);
-        custom.PairAsync(DevicePairingKinds::ConfirmOnly, DevicePairingProtectionLevel::Encryption)
+        custom.PairAsync(kinds, DevicePairingProtectionLevel::Encryption)
             .Completed(completed);
     }
     catch (const winrt::hresult_error& e)

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -388,7 +388,9 @@ void BLEManager::OnMaxPduSizeChanged(GattSession session, winrt::Windows::Founda
     mEmit.MTU(uuid, mtu);
 }
 
-bool BLEManager::Pair(const std::string& uuid, winrt::Windows::Devices::Enumeration::DevicePairingKinds kinds)
+bool BLEManager::Pair(const std::string& uuid,
+                      winrt::Windows::Devices::Enumeration::DevicePairingKinds kinds,
+                      winrt::Windows::Devices::Enumeration::DevicePairingProtectionLevel protectionLevel)
 {
     auto it = mDeviceMap.find(uuid);
     if (it == mDeviceMap.end() || !it->second.device.has_value())
@@ -441,18 +443,30 @@ bool BLEManager::Pair(const std::string& uuid, winrt::Windows::Devices::Enumerat
         // surfaces its native pairing dialog after we Accept() below.
         //
         // The PairingRequested lambda must Accept() exactly once for any kind
-        // the caller advertised in `kinds`. For kinds outside the mask we
-        // return without Accept(), which Windows treats as a rejection and the
-        // PairAsync completes with RejectedByHandler / AuthenticationNotAllowed.
-        // We never forward a PIN or password back to JS — Windows drives the UI
-        // for non-ConfirmOnly ceremonies.
+        // the caller advertised in `kinds`. Some devices negotiated through
+        // ConfirmPinMatch can still raise a ConfirmOnly prompt; treat that as a
+        // compatible fallback so pairing does not fail with status=Failed.
+        // For other kinds outside the mask we return without Accept(), which
+        // Windows treats as a rejection and PairAsync completes with
+        // RejectedByHandler / AuthenticationNotAllowed. We never forward a PIN
+        // or password back to JS — Windows drives the UI for non-ConfirmOnly
+        // ceremonies.
         custom = pairing.Custom();
         token = custom.PairingRequested(
             [kinds](winrt::Windows::Devices::Enumeration::DeviceInformationCustomPairing const&,
                 winrt::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs const& args) {
                 auto kind = args.PairingKind();
+                auto kindMask = static_cast<uint32_t>(kind);
+                auto requestedKinds = static_cast<uint32_t>(kinds);
+                bool confirmPinMatchRequested =
+                    (requestedKinds &
+                     static_cast<uint32_t>(
+                         winrt::Windows::Devices::Enumeration::DevicePairingKinds::ConfirmPinMatch)) != 0;
+                bool confirmOnlyFallback =
+                    confirmPinMatchRequested &&
+                    kind == winrt::Windows::Devices::Enumeration::DevicePairingKinds::ConfirmOnly;
                 LOGE("pairing requested, kind=%d", static_cast<int>(kind));
-                if ((static_cast<uint32_t>(kind) & static_cast<uint32_t>(kinds)) != 0)
+                if ((kindMask & requestedKinds) != 0 || confirmOnlyFallback)
                 {
                     args.Accept();
                 }
@@ -461,7 +475,7 @@ bool BLEManager::Pair(const std::string& uuid, winrt::Windows::Devices::Enumerat
             });
         handlerRegistered = true;
         auto completed = bind2(this, &BLEManager::OnPaired, uuid, token, custom);
-        custom.PairAsync(kinds, DevicePairingProtectionLevel::Encryption)
+        custom.PairAsync(kinds, protectionLevel)
             .Completed(completed);
     }
     catch (const winrt::hresult_error& e)

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -435,12 +435,25 @@ bool BLEManager::Pair(const std::string& uuid,
             return true;
         }
 
+        auto unsupportedKinds = static_cast<uint32_t>(
+            winrt::Windows::Devices::Enumeration::DevicePairingKinds::ProvidePin) |
+            static_cast<uint32_t>(
+                winrt::Windows::Devices::Enumeration::DevicePairingKinds::ProvidePassword) |
+            static_cast<uint32_t>(
+                winrt::Windows::Devices::Enumeration::DevicePairingKinds::ConfirmPassword);
+        if ((static_cast<uint32_t>(kinds) & unsupportedKinds) != 0)
+        {
+            mEmit.Paired(uuid, false,
+                         "pairing kinds requiring a PIN or password are not supported");
+            return true;
+        }
+
         // Always go through `pairing.Custom()`: only DeviceInformationCustomPairing
         // accepts a `DevicePairingKinds` mask (DeviceInformationPairing.PairAsync
-        // takes only a protection level). The caller-supplied `kinds` is the set
-        // of ceremonies we know how to handle — for ConfirmOnly this is the
-        // Just Works path (no UI); for DisplayPin / ProvidePin / etc. Windows
-        // surfaces its native pairing dialog after we Accept() below.
+        // takes only a protection level). The caller-supplied `kinds` may
+        // include ConfirmOnly, DisplayPin, or ConfirmPinMatch; PIN/password
+        // ceremonies are rejected before we get here because this library does
+        // not provide a way to collect or forward secrets to Accept(...).
         //
         // The PairingRequested lambda must Accept() exactly once for any kind
         // the caller advertised in `kinds`. Some devices negotiated through
@@ -474,6 +487,7 @@ bool BLEManager::Pair(const std::string& uuid,
                 // Windows treats the handler returning as a rejection.
             });
         handlerRegistered = true;
+
         auto completed = bind2(this, &BLEManager::OnPaired, uuid, token, custom);
         custom.PairAsync(kinds, protectionLevel)
             .Completed(completed);

--- a/lib/win/src/ble_manager.h
+++ b/lib/win/src/ble_manager.h
@@ -22,7 +22,10 @@ public:
     void Scan(const std::vector<winrt::guid>& serviceUUIDs, bool allowDuplicates);
     void StopScan();
     bool Connect(const std::string& uuid);
-    bool Pair(const std::string& uuid, winrt::Windows::Devices::Enumeration::DevicePairingKinds kinds);
+    bool Pair(
+        const std::string& uuid,
+        winrt::Windows::Devices::Enumeration::DevicePairingKinds kinds,
+        winrt::Windows::Devices::Enumeration::DevicePairingProtectionLevel protectionLevel);
     bool Disconnect(const std::string& uuid);
     bool CancelConnect(const std::string& uuid);
     bool UpdateRSSI(const std::string& uuid);

--- a/lib/win/src/ble_manager.h
+++ b/lib/win/src/ble_manager.h
@@ -22,7 +22,7 @@ public:
     void Scan(const std::vector<winrt::guid>& serviceUUIDs, bool allowDuplicates);
     void StopScan();
     bool Connect(const std::string& uuid);
-    bool Pair(const std::string& uuid);
+    bool Pair(const std::string& uuid, winrt::Windows::Devices::Enumeration::DevicePairingKinds kinds);
     bool Disconnect(const std::string& uuid);
     bool CancelConnect(const std::string& uuid);
     bool UpdateRSSI(const std::string& uuid);

--- a/lib/win/src/napi_winrt.cc
+++ b/lib/win/src/napi_winrt.cc
@@ -71,18 +71,23 @@ bool getBool(const Napi::Value& value, bool def)
 
 uint32_t getUint32(const Napi::Value& value, uint32_t def)
 {
-    if (value.IsNumber())
+    if (!value.IsNumber())
     {
-        double asDouble = value.As<Napi::Number>().DoubleValue();
-        // Reject fractional values to surface caller-side bugs (e.g. a float
-        // that crept in from arithmetic) instead of silently truncating with
-        // Uint32Value(). `DoubleValue() == asDouble` is exact for values in
-        // the int32 range, so the int32 fast path is unaffected.
-        if (asDouble != static_cast<double>(static_cast<int64_t>(asDouble)))
-        {
-            return def;
-        }
-        return static_cast<uint32_t>(asDouble);
+        return def;
     }
-    return def;
+    
+    const double asDouble = value.As<Napi::Number>().DoubleValue();
+    // Reject NaN / infinities / negatives / values outside uint32 range.
+    // (NaN makes both comparisons false, so it is rejected here.)
+    if (!(asDouble >= 0.0 && asDouble <= 4294967295.0))
+    {
+        return def;
+    }
+    const uint32_t asUint32 = static_cast<uint32_t>(asDouble);
+    // Reject fractional values (and values not exactly representable as uint32).
+    if (asDouble != static_cast<double>(asUint32))
+    {
+        return def;
+    }
+    return asUint32;
 }

--- a/lib/win/src/napi_winrt.cc
+++ b/lib/win/src/napi_winrt.cc
@@ -68,3 +68,21 @@ bool getBool(const Napi::Value& value, bool def)
     }
     return def;
 }
+
+uint32_t getUint32(const Napi::Value& value, uint32_t def)
+{
+    if (value.IsNumber())
+    {
+        double asDouble = value.As<Napi::Number>().DoubleValue();
+        // Reject fractional values to surface caller-side bugs (e.g. a float
+        // that crept in from arithmetic) instead of silently truncating with
+        // Uint32Value(). `DoubleValue() == asDouble` is exact for values in
+        // the int32 range, so the int32 fast path is unaffected.
+        if (asDouble != static_cast<double>(static_cast<int64_t>(asDouble)))
+        {
+            return def;
+        }
+        return static_cast<uint32_t>(asDouble);
+    }
+    return def;
+}

--- a/lib/win/src/napi_winrt.h
+++ b/lib/win/src/napi_winrt.h
@@ -6,6 +6,7 @@
 
 std::vector<winrt::guid> getUuidArray(const Napi::Value& value);
 bool getBool(const Napi::Value& value, bool def);
+uint32_t getUint32(const Napi::Value& value, uint32_t def);
 
 winrt::guid napiToUuid(Napi::String string);
 Data napiToData(Napi::Buffer<unsigned char> buffer);

--- a/lib/win/src/noble_winrt.cc
+++ b/lib/win/src/noble_winrt.cc
@@ -101,7 +101,7 @@ Napi::Value NobleWinrt::Connect(const Napi::CallbackInfo& info)
     return info.Env().Undefined();
 }
 
-// pair(deviceUuid, kinds?)
+// pair(deviceUuid, kinds?, protectionLevel?)
 Napi::Value NobleWinrt::Pair(const Napi::CallbackInfo& info)
 {
     CHECK_MANAGER()
@@ -117,9 +117,12 @@ Napi::Value NobleWinrt::Pair(const Napi::CallbackInfo& info)
     // with RejectedByHandler), instead of silently falling through to a
     // ceremony the caller never asked for.
     using winrt::Windows::Devices::Enumeration::DevicePairingKinds;
+    using winrt::Windows::Devices::Enumeration::DevicePairingProtectionLevel;
     auto kinds = static_cast<DevicePairingKinds>(
         getUint32(info[1], static_cast<uint32_t>(DevicePairingKinds::None)));
-    manager->Pair(uuid, kinds);
+    auto protectionLevel = static_cast<DevicePairingProtectionLevel>(
+        getUint32(info[2], static_cast<uint32_t>(DevicePairingProtectionLevel::Encryption)));
+    manager->Pair(uuid, kinds, protectionLevel);
     return info.Env().Undefined();
 }
 

--- a/lib/win/src/noble_winrt.cc
+++ b/lib/win/src/noble_winrt.cc
@@ -101,13 +101,25 @@ Napi::Value NobleWinrt::Connect(const Napi::CallbackInfo& info)
     return info.Env().Undefined();
 }
 
-// pair(deviceUuid)
+// pair(deviceUuid, kinds?)
 Napi::Value NobleWinrt::Pair(const Napi::CallbackInfo& info)
 {
     CHECK_MANAGER()
     ARG1(String)
     auto uuid = info[0].As<Napi::String>().Utf8Value();
-    manager->Pair(uuid);
+
+    // `kinds` is a DevicePairingKinds bitmask. The JS layer (noble.js) is
+    // expected to normalize the value before forwarding here — including
+    // rejecting DevicePairingKinds.None — so any default we pick is a
+    // belt-and-suspenders backstop, not a primary code path. We default
+    // to None (0) rather than ConfirmOnly to surface unexpected callers
+    // via the lambda's `(kind & kinds) == 0` check (PairAsync will fail
+    // with RejectedByHandler), instead of silently falling through to a
+    // ceremony the caller never asked for.
+    using winrt::Windows::Devices::Enumeration::DevicePairingKinds;
+    auto kinds = static_cast<DevicePairingKinds>(
+        getUint32(info[1], static_cast<uint32_t>(DevicePairingKinds::None)));
+    manager->Pair(uuid, kinds);
     return info.Env().Undefined();
 }
 

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -8,4 +8,13 @@ describe('public exports', () => {
       'Connection Failed to be Established'
     );
   });
+
+  test('exposes DevicePairingProtectionLevel constants', () => {
+    expect(noble.DevicePairingProtectionLevel).toEqual({
+      Default: 0,
+      None: 1,
+      Encryption: 2,
+      EncryptionAndAuthentication: 3,
+    });
+  });
 });

--- a/test/lib/peripheral.test.js
+++ b/test/lib/peripheral.test.js
@@ -181,7 +181,7 @@ describe('peripheral', () => {
     test('should delegate to noble, forwarding the callback', () => {
       peripheral.pair();
 
-      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, undefined);
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, undefined, undefined);
       expect(mockNoble.pair).toHaveBeenCalledTimes(1);
     });
 
@@ -190,14 +190,14 @@ describe('peripheral', () => {
 
       peripheral.pair(callback);
 
-      // `kind` is forwarded as undefined (1st-arg-was-callback swap), and the
-      // callback is in the 3rd position (noble.pair's new signature).
-      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, callback);
+      // `kind`/`protectionLevel` are forwarded as undefined
+      // (1st-arg-was-callback swap), and callback is in the 4th position.
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, undefined, callback);
       expect(mockNoble.pair).toHaveBeenCalledTimes(1);
 
       // Noble releases the delegated callback through the internal pair:${id}
       // event, so drive the callback it received rather than the peripheral.
-      mockNoble.pair.mock.calls[0][2](null);
+      mockNoble.pair.mock.calls[0][3](null);
       expect(callback).toHaveBeenCalledWith(null);
       expect(callback).toHaveBeenCalledTimes(1);
     });
@@ -207,7 +207,7 @@ describe('peripheral', () => {
       const error = new Error('pairing failed');
 
       peripheral.pair(callback);
-      mockNoble.pair.mock.calls[0][2](error);
+      mockNoble.pair.mock.calls[0][3](error);
 
       expect(callback).toHaveBeenCalledWith(error);
       expect(callback).toHaveBeenCalledTimes(1);
@@ -225,7 +225,7 @@ describe('peripheral', () => {
       peripheral.emit('pair', new Error('late completion after removal'));
       expect(callback).not.toHaveBeenCalled();
 
-      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, callback);
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, undefined, callback);
     });
 
     test('should forward explicit kind alongside callback', () => {
@@ -234,7 +234,18 @@ describe('peripheral', () => {
 
       peripheral.pair(kind, callback);
 
-      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, kind, callback);
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, kind, undefined, callback);
+      expect(mockNoble.pair).toHaveBeenCalledTimes(1);
+    });
+
+    test('should forward explicit protection level alongside kind + callback', () => {
+      const kind = 0x00000008; // ConfirmOnly
+      const protectionLevel = 3; // EncryptionAndAuthentication
+      const callback = jest.fn();
+
+      peripheral.pair(kind, protectionLevel, callback);
+
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, kind, protectionLevel, callback);
       expect(mockNoble.pair).toHaveBeenCalledTimes(1);
     });
   });
@@ -243,17 +254,17 @@ describe('peripheral', () => {
     test('should resolve on success', async () => {
       const promise = peripheral.pairAsync();
       // Noble releases the delegated callback via pair:${id}; simulate it.
-      // After kind-swap, pairAsync calls noble.pair(id, undefined, callback).
-      mockNoble.pair.mock.calls[0][2](null);
+      // After kind-swap, pairAsync calls noble.pair(id, undefined, undefined, callback).
+      mockNoble.pair.mock.calls[0][3](null);
 
       await expect(promise).resolves.toBeUndefined();
-      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, expect.any(Function));
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, undefined, expect.any(Function));
       expect(mockNoble.pair).toHaveBeenCalledTimes(1);
     });
 
     test('should reject on error', async () => {
       const promise = peripheral.pairAsync();
-      mockNoble.pair.mock.calls[0][2](new Error('pairing failed'));
+      mockNoble.pair.mock.calls[0][3](new Error('pairing failed'));
 
       await expect(promise).rejects.toThrow('pairing failed');
     });
@@ -261,10 +272,21 @@ describe('peripheral', () => {
     test('should forward explicit kind', async () => {
       const kind = 0x00000010; // DisplayPin
       const promise = peripheral.pairAsync(kind);
-      mockNoble.pair.mock.calls[0][2](null);
+      mockNoble.pair.mock.calls[0][3](null);
 
       await expect(promise).resolves.toBeUndefined();
-      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, kind, expect.any(Function));
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, kind, undefined, expect.any(Function));
+      expect(mockNoble.pair).toHaveBeenCalledTimes(1);
+    });
+
+    test('should forward explicit protection level', async () => {
+      const kind = 0x00000010; // DisplayPin
+      const protectionLevel = 1; // None
+      const promise = peripheral.pairAsync(kind, protectionLevel);
+      mockNoble.pair.mock.calls[0][3](null);
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, kind, protectionLevel, expect.any(Function));
       expect(mockNoble.pair).toHaveBeenCalledTimes(1);
     });
   });

--- a/test/lib/peripheral.test.js
+++ b/test/lib/peripheral.test.js
@@ -33,7 +33,8 @@ describe('peripheral', () => {
       updateRssi: jest.fn(),
       discoverServices: jest.fn(),
       readHandle: jest.fn(),
-      writeHandle: jest.fn()
+      writeHandle: jest.fn(),
+      pair: jest.fn()
     };
     
     peripheral = new Peripheral(
@@ -181,7 +182,7 @@ describe('peripheral', () => {
     test('should delegate to noble, forwarding the callback', () => {
       peripheral.pair();
 
-      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined);
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, undefined);
       expect(mockNoble.pair).toHaveBeenCalledTimes(1);
     });
 
@@ -190,12 +191,14 @@ describe('peripheral', () => {
 
       peripheral.pair(callback);
 
-      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, callback);
+      // `kind` is forwarded as undefined (1st-arg-was-callback swap), and the
+      // callback is in the 3rd position (noble.pair's new signature).
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, callback);
       expect(mockNoble.pair).toHaveBeenCalledTimes(1);
 
       // Noble releases the delegated callback through the internal pair:${id}
       // event, so drive the callback it received rather than the peripheral.
-      mockNoble.pair.mock.calls[0][1](null);
+      mockNoble.pair.mock.calls[0][2](null);
       expect(callback).toHaveBeenCalledWith(null);
       expect(callback).toHaveBeenCalledTimes(1);
     });
@@ -205,7 +208,7 @@ describe('peripheral', () => {
       const error = new Error('pairing failed');
 
       peripheral.pair(callback);
-      mockNoble.pair.mock.calls[0][1](error);
+      mockNoble.pair.mock.calls[0][2](error);
 
       expect(callback).toHaveBeenCalledWith(error);
       expect(callback).toHaveBeenCalledTimes(1);
@@ -223,7 +226,17 @@ describe('peripheral', () => {
       peripheral.emit('pair', new Error('late completion after removal'));
       expect(callback).not.toHaveBeenCalled();
 
-      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, callback);
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, callback);
+    });
+
+    test('should forward explicit kind alongside callback', () => {
+      const kind = 0x00000010; // DevicePairingKinds.DisplayPin
+      const callback = jest.fn();
+
+      peripheral.pair(kind, callback);
+
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, kind, callback);
+      expect(mockNoble.pair).toHaveBeenCalledTimes(1);
     });
   });
 
@@ -231,18 +244,29 @@ describe('peripheral', () => {
     test('should resolve on success', async () => {
       const promise = peripheral.pairAsync();
       // Noble releases the delegated callback via pair:${id}; simulate it.
-      mockNoble.pair.mock.calls[0][1](null);
+      // After kind-swap, pairAsync calls noble.pair(id, undefined, callback).
+      mockNoble.pair.mock.calls[0][2](null);
 
       await expect(promise).resolves.toBeUndefined();
-      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, expect.any(Function));
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, expect.any(Function));
       expect(mockNoble.pair).toHaveBeenCalledTimes(1);
     });
 
     test('should reject on error', async () => {
       const promise = peripheral.pairAsync();
-      mockNoble.pair.mock.calls[0][1](new Error('pairing failed'));
+      mockNoble.pair.mock.calls[0][2](new Error('pairing failed'));
 
       await expect(promise).rejects.toThrow('pairing failed');
+    });
+
+    test('should forward explicit kind', async () => {
+      const kind = 0x00000010; // DisplayPin
+      const promise = peripheral.pairAsync(kind);
+      mockNoble.pair.mock.calls[0][2](null);
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, kind, expect.any(Function));
+      expect(mockNoble.pair).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/test/lib/peripheral.test.js
+++ b/test/lib/peripheral.test.js
@@ -33,8 +33,7 @@ describe('peripheral', () => {
       updateRssi: jest.fn(),
       discoverServices: jest.fn(),
       readHandle: jest.fn(),
-      writeHandle: jest.fn(),
-      pair: jest.fn()
+      writeHandle: jest.fn()
     };
     
     peripheral = new Peripheral(

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -635,6 +635,94 @@ describe('noble', () => {
     });
   });
 
+  describe('pair', () => {
+    // Mirror lib/pairing-kinds.js — kept in sync manually since these tests
+    // exercise the JS layer (no WinRT binding in scope).
+    const DevicePairingKinds = {
+      None: 0,
+      ConfirmOnly: 0x00000008,
+      DisplayPin: 0x00000010,
+      ProvidePin: 0x00000040,
+    };
+
+    // Use a hex id so `_getPeripheralId` accepts it without calling the
+    // mocked addressToId (whose return value would otherwise become the
+    // forwarded identifier).
+    const peripheralUuidHex = '00112233445566778899aabbccddeeff';
+
+    test('should default to ConfirmOnly when kind is omitted', () => {
+      mockBindings.pair = jest.fn();
+      noble.pair(peripheralUuidHex, () => {});
+      expect(mockBindings.pair).toHaveBeenCalledWith(
+        peripheralUuidHex,
+        DevicePairingKinds.ConfirmOnly
+      );
+    });
+
+    test('should forward explicit kind to the binding', () => {
+      mockBindings.pair = jest.fn();
+      noble.pair(peripheralUuidHex, DevicePairingKinds.DisplayPin, () => {});
+      expect(mockBindings.pair).toHaveBeenCalledWith(
+        peripheralUuidHex,
+        DevicePairingKinds.DisplayPin
+      );
+    });
+
+    test('should accept a bitmask kind (multiple OR-ed values)', () => {
+      mockBindings.pair = jest.fn();
+      const mask = DevicePairingKinds.ConfirmOnly | DevicePairingKinds.ProvidePin;
+      noble.pair(peripheralUuidHex, mask, () => {});
+      expect(mockBindings.pair).toHaveBeenCalledWith(peripheralUuidHex, mask);
+    });
+
+    test('should treat function in 2nd position as callback (legacy signature)', () => {
+      mockBindings.pair = jest.fn();
+      const cb = jest.fn();
+      noble.pair(peripheralUuidHex, cb);
+      expect(mockBindings.pair).toHaveBeenCalledWith(
+        peripheralUuidHex,
+        DevicePairingKinds.ConfirmOnly
+      );
+    });
+
+    test('pairAsync should default to ConfirmOnly', async () => {
+      mockBindings.pair = jest.fn();
+      const promise = noble.pairAsync(peripheralUuidHex);
+      // pairAsync awaits a `pair:${identifier}` event; emit success
+      // (null error) to resolve the promise.
+      noble.emit(`pair:${peripheralUuidHex}`, null);
+
+      await promise;
+      expect(mockBindings.pair).toHaveBeenCalledWith(
+        peripheralUuidHex,
+        DevicePairingKinds.ConfirmOnly
+      );
+    });
+
+    test('pairAsync should forward explicit kind', async () => {
+      mockBindings.pair = jest.fn();
+      const promise = noble.pairAsync(peripheralUuidHex, DevicePairingKinds.ProvidePin);
+      noble.emit(`pair:${peripheralUuidHex}`, null);
+
+      await promise;
+      expect(mockBindings.pair).toHaveBeenCalledWith(
+        peripheralUuidHex,
+        DevicePairingKinds.ProvidePin
+      );
+    });
+
+    test('should surface deterministic error when binding has no pair method', () => {
+      mockBindings.pair = jest.fn();
+      delete mockBindings.pair;
+      const cb = jest.fn();
+      noble.pair(peripheralUuidHex, DevicePairingKinds.DisplayPin, cb);
+      expect(cb).toHaveBeenCalledTimes(1);
+      const err = cb.mock.calls[0][0];
+      expect(err).toBeInstanceOf(Error);
+      expect(err.message).toBe('Pairing is not supported on this platform');
+    });
+  });
+
   describe('onDisconnect', () => {
     test('should emit disconnect on existing peripheral', () => {
       const emit = jest.fn();
@@ -667,13 +755,23 @@ describe('noble', () => {
   });
 
   describe('pair', () => {
-    test('should delegate to binding', () => {
+    // Mirror lib/pairing-kinds.js — used by these legacy tests for assertions
+    // when the new pair() defaults to ConfirmOnly.
+    const DevicePairingKinds = {
+      None: 0,
+      ConfirmOnly: 0x00000008,
+    };
+
+    test('should delegate to binding with ConfirmOnly default', () => {
       const peripheralUuid = 'aabbccddeeff';
 
       mockBindings.pair = jest.fn();
       noble.pair(peripheralUuid);
 
-      expect(mockBindings.pair).toHaveBeenCalledWith(peripheralUuid);
+      expect(mockBindings.pair).toHaveBeenCalledWith(
+        peripheralUuid,
+        DevicePairingKinds.ConfirmOnly
+      );
       expect(mockBindings.pair).toHaveBeenCalledTimes(1);
     });
 
@@ -705,6 +803,10 @@ describe('noble', () => {
   });
 
   describe('pairAsync', () => {
+    const DevicePairingKinds = {
+      ConfirmOnly: 0x00000008,
+    };
+
     test('should resolve on success', async () => {
       const peripheralUuid = 'aabbccddeeff';
       mockBindings.pair = jest.fn();
@@ -714,7 +816,10 @@ describe('noble', () => {
       noble._onPair(peripheralUuid, true);
 
       await expect(promise).resolves.toBeUndefined();
-      expect(mockBindings.pair).toHaveBeenCalledWith(peripheralUuid);
+      expect(mockBindings.pair).toHaveBeenCalledWith(
+        peripheralUuid,
+        DevicePairingKinds.ConfirmOnly
+      );
     });
 
     test('should reject on failure', async () => {

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -711,6 +711,19 @@ describe('noble', () => {
       );
     });
 
+
+    test('should reject DevicePairingKinds.None (empty mask)', () => {
+      mockBindings.pair = jest.fn();
+      const cb = jest.fn();
+      noble.pair(peripheralUuidHex, DevicePairingKinds.None, cb);
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledWith(expect.any(Error));
+      expect(cb.mock.calls[0][0].message).toBe(
+        'pair() requires at least one DevicePairingKinds value; DevicePairingKinds.None matches no ceremony'
+      );
+      expect(mockBindings.pair).not.toHaveBeenCalled();
+    });
+
     test('should surface deterministic error when binding has no pair method', () => {
       mockBindings.pair = jest.fn();
       delete mockBindings.pair;

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -768,6 +768,17 @@ describe('noble', () => {
       );
     });
 
+    test('should reject invalid kind values', () => {
+      mockBindings.pair = jest.fn();
+      const cb = jest.fn();
+      noble.pair(peripheralUuidHex, Number.NaN, cb);
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledWith(expect.any(Error));
+      expect(cb.mock.calls[0][0].message).toBe(
+        'pair() kind must be a finite uint32 DevicePairingKinds bitmask'
+      );
+      expect(mockBindings.pair).not.toHaveBeenCalled();
+    });
 
     test('should reject DevicePairingKinds.None (empty mask)', () => {
       mockBindings.pair = jest.fn();
@@ -784,11 +795,11 @@ describe('noble', () => {
     test('should reject invalid protection level type', () => {
       mockBindings.pair = jest.fn();
       const cb = jest.fn();
-      noble.pair(peripheralUuidHex, DevicePairingKinds.ConfirmOnly, 'invalid', cb);
+      noble.pair(peripheralUuidHex, DevicePairingKinds.ConfirmOnly, 1.5, cb);
       expect(cb).toHaveBeenCalledTimes(1);
       expect(cb).toHaveBeenCalledWith(expect.any(Error));
       expect(cb.mock.calls[0][0].message).toBe(
-        'pair() protectionLevel must be a number (DevicePairingProtectionLevel)'
+        'pair() protectionLevel must be a finite uint32 DevicePairingProtectionLevel'
       );
       expect(mockBindings.pair).not.toHaveBeenCalled();
     });

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -644,6 +644,11 @@ describe('noble', () => {
       DisplayPin: 0x00000010,
       ProvidePin: 0x00000040,
     };
+    const DevicePairingProtectionLevel = {
+      None: 1,
+      Encryption: 2,
+      EncryptionAndAuthentication: 3,
+    };
 
     // Use a hex id so `_getPeripheralId` accepts it without calling the
     // mocked addressToId (whose return value would otherwise become the
@@ -655,7 +660,8 @@ describe('noble', () => {
       noble.pair(peripheralUuidHex, () => {});
       expect(mockBindings.pair).toHaveBeenCalledWith(
         peripheralUuidHex,
-        DevicePairingKinds.ConfirmOnly
+        DevicePairingKinds.ConfirmOnly,
+        DevicePairingProtectionLevel.Encryption
       );
     });
 
@@ -664,7 +670,8 @@ describe('noble', () => {
       noble.pair(peripheralUuidHex, DevicePairingKinds.DisplayPin, () => {});
       expect(mockBindings.pair).toHaveBeenCalledWith(
         peripheralUuidHex,
-        DevicePairingKinds.DisplayPin
+        DevicePairingKinds.DisplayPin,
+        DevicePairingProtectionLevel.Encryption
       );
     });
 
@@ -672,7 +679,26 @@ describe('noble', () => {
       mockBindings.pair = jest.fn();
       const mask = DevicePairingKinds.ConfirmOnly | DevicePairingKinds.ProvidePin;
       noble.pair(peripheralUuidHex, mask, () => {});
-      expect(mockBindings.pair).toHaveBeenCalledWith(peripheralUuidHex, mask);
+      expect(mockBindings.pair).toHaveBeenCalledWith(
+        peripheralUuidHex,
+        mask,
+        DevicePairingProtectionLevel.Encryption
+      );
+    });
+
+    test('should forward explicit protection level to the binding', () => {
+      mockBindings.pair = jest.fn();
+      noble.pair(
+        peripheralUuidHex,
+        DevicePairingKinds.ConfirmOnly,
+        DevicePairingProtectionLevel.EncryptionAndAuthentication,
+        () => {}
+      );
+      expect(mockBindings.pair).toHaveBeenCalledWith(
+        peripheralUuidHex,
+        DevicePairingKinds.ConfirmOnly,
+        DevicePairingProtectionLevel.EncryptionAndAuthentication
+      );
     });
 
     test('should treat function in 2nd position as callback (legacy signature)', () => {
@@ -681,7 +707,19 @@ describe('noble', () => {
       noble.pair(peripheralUuidHex, cb);
       expect(mockBindings.pair).toHaveBeenCalledWith(
         peripheralUuidHex,
-        DevicePairingKinds.ConfirmOnly
+        DevicePairingKinds.ConfirmOnly,
+        DevicePairingProtectionLevel.Encryption
+      );
+    });
+
+    test('should treat function in 3rd position as callback (legacy signature)', () => {
+      mockBindings.pair = jest.fn();
+      const cb = jest.fn();
+      noble.pair(peripheralUuidHex, DevicePairingKinds.ConfirmOnly, cb);
+      expect(mockBindings.pair).toHaveBeenCalledWith(
+        peripheralUuidHex,
+        DevicePairingKinds.ConfirmOnly,
+        DevicePairingProtectionLevel.Encryption
       );
     });
 
@@ -695,7 +733,8 @@ describe('noble', () => {
       await promise;
       expect(mockBindings.pair).toHaveBeenCalledWith(
         peripheralUuidHex,
-        DevicePairingKinds.ConfirmOnly
+        DevicePairingKinds.ConfirmOnly,
+        DevicePairingProtectionLevel.Encryption
       );
     });
 
@@ -707,7 +746,25 @@ describe('noble', () => {
       await promise;
       expect(mockBindings.pair).toHaveBeenCalledWith(
         peripheralUuidHex,
-        DevicePairingKinds.ProvidePin
+        DevicePairingKinds.ProvidePin,
+        DevicePairingProtectionLevel.Encryption
+      );
+    });
+
+    test('pairAsync should forward explicit protection level', async () => {
+      mockBindings.pair = jest.fn();
+      const promise = noble.pairAsync(
+        peripheralUuidHex,
+        DevicePairingKinds.ProvidePin,
+        DevicePairingProtectionLevel.None
+      );
+      noble.emit(`pair:${peripheralUuidHex}`, null);
+
+      await promise;
+      expect(mockBindings.pair).toHaveBeenCalledWith(
+        peripheralUuidHex,
+        DevicePairingKinds.ProvidePin,
+        DevicePairingProtectionLevel.None
       );
     });
 
@@ -720,6 +777,18 @@ describe('noble', () => {
       expect(cb).toHaveBeenCalledWith(expect.any(Error));
       expect(cb.mock.calls[0][0].message).toBe(
         'pair() requires at least one DevicePairingKinds value; DevicePairingKinds.None matches no ceremony'
+      );
+      expect(mockBindings.pair).not.toHaveBeenCalled();
+    });
+
+    test('should reject invalid protection level type', () => {
+      mockBindings.pair = jest.fn();
+      const cb = jest.fn();
+      noble.pair(peripheralUuidHex, DevicePairingKinds.ConfirmOnly, 'invalid', cb);
+      expect(cb).toHaveBeenCalledTimes(1);
+      expect(cb).toHaveBeenCalledWith(expect.any(Error));
+      expect(cb.mock.calls[0][0].message).toBe(
+        'pair() protectionLevel must be a number (DevicePairingProtectionLevel)'
       );
       expect(mockBindings.pair).not.toHaveBeenCalled();
     });
@@ -774,6 +843,9 @@ describe('noble', () => {
       None: 0,
       ConfirmOnly: 0x00000008,
     };
+    const DevicePairingProtectionLevel = {
+      Encryption: 2,
+    };
 
     test('should delegate to binding with ConfirmOnly default', () => {
       const peripheralUuid = 'aabbccddeeff';
@@ -783,7 +855,8 @@ describe('noble', () => {
 
       expect(mockBindings.pair).toHaveBeenCalledWith(
         peripheralUuid,
-        DevicePairingKinds.ConfirmOnly
+        DevicePairingKinds.ConfirmOnly,
+        DevicePairingProtectionLevel.Encryption
       );
       expect(mockBindings.pair).toHaveBeenCalledTimes(1);
     });
@@ -819,6 +892,9 @@ describe('noble', () => {
     const DevicePairingKinds = {
       ConfirmOnly: 0x00000008,
     };
+    const DevicePairingProtectionLevel = {
+      Encryption: 2,
+    };
 
     test('should resolve on success', async () => {
       const peripheralUuid = 'aabbccddeeff';
@@ -831,7 +907,8 @@ describe('noble', () => {
       await expect(promise).resolves.toBeUndefined();
       expect(mockBindings.pair).toHaveBeenCalledWith(
         peripheralUuid,
-        DevicePairingKinds.ConfirmOnly
+        DevicePairingKinds.ConfirmOnly,
+        DevicePairingProtectionLevel.Encryption
       );
     });
 


### PR DESCRIPTION
-  pair now supports both pairing kind and security level.  
-  Backward-compatible defaults are preserved (ConfirmOnly + Encryption).  