### PR TITLE
feat(win): support authenticated PIN pairing

### DIFF
--- a/README.md
+++ b/README.md
@@ -396,9 +396,18 @@ await noble.pairAsync(idOrAddress);
 // or
 await peripheral.pairAsync();
 
+// Supply a PIN for authenticated Windows pairing ceremonies.
+await peripheral.pairAsync({ pin: '123456' });
+
+// A connected peripheral can be checked before prompting the user for a PIN.
+if (!peripheral.isPaired()) {
+  // request a PIN and pair
+}
+
 // Callback form is also available on both.
 noble.pair(idOrAddress, error => { /* ... */ });
 peripheral.pair(error => { /* ... */ });
+peripheral.pair({ pin: '123456' }, error => { /* ... */ });
 
 // The pairing outcome is emitted on the peripheral, and (subject, error)
 // on Noble, mirroring other events.
@@ -415,13 +424,15 @@ noble.on('pair', (peripheral, error) => { /* ... */ });
 - **A connected device is required.** The peripheral must already be
   discovered and connected (present in Noble's peripheral map) before pairing
   is requested. Pairing an unknown/untracked id fails rather than hanging.
-- **Only the `ConfirmOnly` ("Just Works") ceremony is supported.** The
-  handler auto-accepts `ConfirmOnly` requests without a UI prompt. Any other
-  ceremony (`DisplayPin`, `ProvidePassword`, `ConfirmPinMatch`, …) is **not**
-  accepted — this library has no UI to surface a PIN or password — and Windows
-  completes the operation with the corresponding failure status
-  (e.g. `RejectedByHandler` / `AuthenticationNotAllowed`), which is reported
-  back through the `pair` callback/event.
+- **`ConfirmOnly` ("Just Works") remains the default.** Calling `pair` without
+  a PIN preserves the existing behavior and protection level. Passing
+  `{ pin: string }` additionally enables the `ProvidePin` and
+  `ConfirmPinMatch` ceremonies and requests authenticated encryption. Noble
+  does not display pairing UI; applications remain responsible for securely
+  collecting the PIN from the user.
+- **`isPaired` is Windows-only state.** It returns `false` when the active
+  binding does not expose pairing state, or when the peripheral is not
+  connected and tracked by the Windows binding.
 
 ### Service Methods
 

--- a/README.md
+++ b/README.md
@@ -408,6 +408,14 @@ await noble.pairAsync(
   DevicePairingProtectionLevel.EncryptionAndAuthentication
 );
 
+// Or supply a PIN for authenticated ProvidePin / ConfirmPinMatch pairing.
+await peripheral.pairAsync({ pin: '123456' });
+
+// A connected peripheral can be checked before prompting for a PIN.
+if (!peripheral.isPaired()) {
+  // request a PIN and pair
+}
+
 // Callback form is also available on both.
 noble.pair(idOrAddress, error => { /* ... */ });
 peripheral.pair(error => { /* ... */ });
@@ -432,8 +440,14 @@ noble.on('pair', (peripheral, error) => { /* ... */ });
   `DevicePairingKinds` bitmask (single or OR-ed values) and (optionally)
   `DevicePairingProtectionLevel`.
   `ConfirmOnly`, `DisplayPin`, and `ConfirmPinMatch` use Windows' native UI;
-  PIN/password kinds (`ProvidePin`, `ProvidePassword`, `ConfirmPassword`) are
-  rejected because this library does not collect secrets to pass into WinRT.
+  password kinds (`ProvidePassword`, `ConfirmPassword`) remain unsupported.
+- **PIN options.** Passing `{ pin: string }` defaults the ceremony mask to
+  `ConfirmOnly | ProvidePin | ConfirmPinMatch` and the protection level to
+  `EncryptionAndAuthentication`. Noble never logs the PIN; applications remain
+  responsible for collecting and retaining it securely.
+- **`isPaired` is Windows-only state.** It returns `false` when the active
+  binding does not expose pairing state, or when the peripheral is not
+  connected and tracked by the Windows binding.
 
 ### Service Methods
 

--- a/index.d.ts
+++ b/index.d.ts
@@ -33,6 +33,11 @@ declare module '@stoprocent/noble' {
         timeout?: number;
     }
 
+    export interface PairOptions {
+        /** PIN displayed by or configured on the peripheral. Windows only. */
+        pin?: string;
+    }
+
     export class Noble extends EventEmitter {
     
         constructor(bindings: any);
@@ -45,22 +50,25 @@ declare module '@stoprocent/noble' {
         stopScanningAsync(): Promise<void>;
         discoverAsync(): AsyncGenerator<Peripheral, void, unknown>;
         connectAsync(idOrAddress: PeripheralIdOrAddress, options?: ConnectOptions): Promise<Peripheral>;
+        /** Windows only; returns whether WinRT reports that the device is paired. */
+        isPaired(idOrAddress: PeripheralIdOrAddress): boolean;
         /**
          * Pair with a peripheral. Windows only; requires an already-connected
-         * peripheral and supports only the ConfirmOnly ("Just Works") ceremony.
+         * peripheral and supports ConfirmOnly plus caller-supplied PIN ceremonies.
          * Rejects with 'Pairing is not supported on this platform' elsewhere.
          */
-        pairAsync(idOrAddress: PeripheralIdOrAddress): Promise<void>;
+        pairAsync(idOrAddress: PeripheralIdOrAddress, options?: PairOptions): Promise<void>;
 
         startScanning(serviceUUIDs?: string[], allowDuplicates?: boolean, callback?: (error?: Error) => void): void;
         stopScanning(callback?: () => void): void;
         connect(idOrAddress: PeripheralIdOrAddress, options?: ConnectOptions, callback?: (error: Error | undefined, peripheral: Peripheral) => void): void;
         /**
          * Pair with a peripheral. Windows only; requires an already-connected
-         * peripheral and supports only the ConfirmOnly ("Just Works") ceremony.
+         * peripheral and supports ConfirmOnly plus caller-supplied PIN ceremonies.
          * Calls back with 'Pairing is not supported on this platform' elsewhere.
          */
         pair(idOrAddress: PeripheralIdOrAddress, callback?: (error: Error | null) => void): void;
+        pair(idOrAddress: PeripheralIdOrAddress, options: PairOptions, callback?: (error: Error | null) => void): void;
         cancelConnect(idOrAddress: PeripheralIdOrAddress, options?: object): void;
         reset(): void;
         stop(): void;
@@ -119,8 +127,10 @@ declare module '@stoprocent/noble' {
         readonly uuid: string;
     
         connectAsync(): Promise<void>;
-        /** Windows only; ConfirmOnly ("Just Works") ceremony only. */
-        pairAsync(): Promise<void>;
+        /** Windows only; returns whether WinRT reports that the device is paired. */
+        isPaired(): boolean;
+        /** Windows only; supports ConfirmOnly and caller-supplied PIN ceremonies. */
+        pairAsync(options?: PairOptions): Promise<void>;
         disconnectAsync(): Promise<void>;
         updateRssiAsync(): Promise<number>;
         discoverServicesAsync(): Promise<Service[]>;
@@ -131,8 +141,9 @@ declare module '@stoprocent/noble' {
         writeHandleAsync(handle: number, data: Buffer, withoutResponse: boolean): Promise<void>;
 
         connect(callback?: (error: Error | undefined) => void): void;
-        /** Windows only; ConfirmOnly ("Just Works") ceremony only. */
+        /** Windows only; supports ConfirmOnly and caller-supplied PIN ceremonies. */
         pair(callback?: (error: Error | null) => void): void;
+        pair(options: PairOptions, callback?: (error: Error | null) => void): void;
         disconnect(callback?: () => void): void;
         updateRssi(callback?: (error: Error | undefined, rssi: number) => void): void;
         discoverServices(): void;

--- a/index.d.ts
+++ b/index.d.ts
@@ -63,6 +63,11 @@ declare module '@stoprocent/noble' {
         timeout?: number;
     }
 
+    export interface PairOptions {
+        /** PIN displayed by or configured on the peripheral. Windows only. */
+        pin?: string;
+    }
+
     export class Noble extends EventEmitter {
     
         constructor(bindings: any);
@@ -75,6 +80,9 @@ declare module '@stoprocent/noble' {
         stopScanningAsync(): Promise<void>;
         discoverAsync(): AsyncGenerator<Peripheral, void, unknown>;
         connectAsync(idOrAddress: PeripheralIdOrAddress, options?: ConnectOptions): Promise<Peripheral>;
+        /** Windows only; returns whether WinRT reports that the device is paired. */
+        isPaired(idOrAddress: PeripheralIdOrAddress): boolean;
+        pairAsync(idOrAddress: PeripheralIdOrAddress, options?: PairOptions): Promise<void>;
         pairAsync(idOrAddress: PeripheralIdOrAddress, kind?: DevicePairingKinds, protectionLevel?: DevicePairingProtectionLevel): Promise<void>;
 
         startScanning(serviceUUIDs?: string[], allowDuplicates?: boolean, callback?: (error?: Error) => void): void;
@@ -88,14 +96,13 @@ declare module '@stoprocent/noble' {
      /**
       * Pair with a peripheral. `kind` defaults to
       * `DevicePairingKinds.ConfirmOnly` and `protectionLevel` defaults to
-     * `DevicePairingProtectionLevel.Encryption`. On Windows, `ConfirmOnly`,
-     * `DisplayPin`, and `ConfirmPinMatch` use the OS pairing dialog. PIN /
-     * password kinds (`ProvidePin`, `ProvidePassword`, `ConfirmPassword`) are
-     * rejected because this library does not collect secrets to pass into
-     * WinRT. On non-Windows platforms the call surfaces a "Pairing is not
-     * supported" error.
-     */
+      * `DevicePairingProtectionLevel.Encryption`. PairOptions can supply a PIN,
+      * enabling ConfirmOnly, ProvidePin, and ConfirmPinMatch with authenticated
+      * encryption. On non-Windows platforms the call surfaces a "Pairing is
+      * not supported" error.
+      */
         pair(idOrAddress: PeripheralIdOrAddress, callback: (error: Error | undefined) => void): void;
+        pair(idOrAddress: PeripheralIdOrAddress, options: PairOptions, callback?: (error: Error | undefined) => void): void;
         pair(idOrAddress: PeripheralIdOrAddress, kind?: DevicePairingKinds, callback?: (error: Error | undefined) => void): void;
         pair(idOrAddress: PeripheralIdOrAddress, kind: DevicePairingKinds, protectionLevel: DevicePairingProtectionLevel, callback?: (error: Error | undefined) => void): void;
     
@@ -152,6 +159,9 @@ declare module '@stoprocent/noble' {
         readonly uuid: string;
     
         connectAsync(): Promise<void>;
+        /** Windows only; returns whether WinRT reports that the device is paired. */
+        isPaired(): boolean;
+        pairAsync(options?: PairOptions): Promise<void>;
         pairAsync(kind?: DevicePairingKinds, protectionLevel?: DevicePairingProtectionLevel): Promise<void>;
         disconnectAsync(): Promise<void>;
         updateRssiAsync(): Promise<number>;
@@ -164,6 +174,7 @@ declare module '@stoprocent/noble' {
 
         connect(callback?: (error: Error | undefined) => void): void;
         pair(callback: (error: Error | undefined) => void): void;
+        pair(options: PairOptions, callback?: (error: Error | undefined) => void): void;
         pair(kind?: DevicePairingKinds, callback?: (error: Error | undefined) => void): void;
         pair(kind: DevicePairingKinds, protectionLevel: DevicePairingProtectionLevel, callback?: (error: Error | undefined) => void): void;
         disconnect(callback?: () => void): void;

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -433,7 +433,16 @@ class Noble extends NobleEventEmitter {
     }
   }
 
-  pair (idOrAddress, callback) {
+  isPaired (idOrAddress) {
+    const identifier = this._getPeripheralId(idOrAddress);
+    return typeof this._bindings.isPaired === 'function' && this._bindings.isPaired(identifier) === true;
+  }
+
+  pair (idOrAddress, options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = undefined;
+    }
     const identifier = this._getPeripheralId(idOrAddress);
     if (typeof callback === 'function') {
       this.onceExclusive(`pair:${identifier}`, error => callback(error));
@@ -455,12 +464,16 @@ class Noble extends NobleEventEmitter {
       this.emit(`pair:${identifier}`, err);
       return;
     }
-    this._bindings.pair(identifier);
+    if (typeof options?.pin === 'string') {
+      this._bindings.pair(identifier, options.pin);
+    } else {
+      this._bindings.pair(identifier);
+    }
   }
 
-  async pairAsync (idOrAddress) {
+  async pairAsync (idOrAddress, options) {
     return new Promise((resolve, reject) => {
-      this.pair(idOrAddress, error => error ? reject(error) : resolve());
+      this.pair(idOrAddress, options, error => error ? reject(error) : resolve());
     });
   }
 

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -436,15 +436,27 @@ class Noble extends NobleEventEmitter {
     }
   }
 
+  isPaired (idOrAddress) {
+    const identifier = this._getPeripheralId(idOrAddress);
+    return typeof this._bindings.isPaired === 'function' && this._bindings.isPaired(identifier) === true;
+  }
+
   pair (idOrAddress, kind, protectionLevel, callback) {
     const identifier = this._getPeripheralId(idOrAddress);
+    let pin;
 
-    // Backward compat: `pair(id, callback)` — the legacy signature passes
-    // the callback in the 2nd position. Detect that and default `kind` to
-    // ConfirmOnly so existing callers see no behavior change. The new
-    // signature's `kind` is a number, so a function in this slot is
-    // unambiguously the legacy callback.
-    if (typeof kind === 'function') {
+    // PairOptions selects the authenticated PIN path. The positional
+    // kind/protectionLevel signatures remain available for the upstream
+    // custom-pairing API.
+    if (kind !== null && typeof kind === 'object' && !Array.isArray(kind)) {
+      const options = kind;
+      if (typeof protectionLevel === 'function') {
+        callback = protectionLevel;
+      }
+      kind = undefined;
+      protectionLevel = undefined;
+      pin = options.pin;
+    } else if (typeof kind === 'function') {
       callback = kind;
       kind = undefined;
       protectionLevel = undefined;
@@ -452,6 +464,16 @@ class Noble extends NobleEventEmitter {
       callback = protectionLevel;
       protectionLevel = undefined;
     }
+    if (pin !== undefined && typeof pin !== 'string') {
+      const err = new Error('pair() options.pin must be a string');
+      if (typeof callback === 'function') {
+        callback(err);
+      } else {
+        this.emit('warning', err.message);
+      }
+      return;
+    }
+    const hasPin = typeof pin === 'string' && pin.length > 0;
     if (kind !== undefined && kind !== null && !isUint32(kind)) {
       const err = new Error('pair() kind must be a finite uint32 DevicePairingKinds bitmask');
       if (typeof callback === 'function') {
@@ -475,7 +497,9 @@ class Noble extends NobleEventEmitter {
       return;
     }
     const pairingKind = (kind === undefined || kind === null)
-      ? DevicePairingKinds.ConfirmOnly
+      ? (hasPin
+          ? DevicePairingKinds.ConfirmOnly | DevicePairingKinds.ProvidePin | DevicePairingKinds.ConfirmPinMatch
+          : DevicePairingKinds.ConfirmOnly)
       : kind;
     if (protectionLevel !== undefined &&
         protectionLevel !== null &&
@@ -489,7 +513,9 @@ class Noble extends NobleEventEmitter {
       return;
     }
     const pairingProtectionLevel = (protectionLevel === undefined || protectionLevel === null)
-      ? DevicePairingProtectionLevel.Encryption
+      ? (hasPin
+          ? DevicePairingProtectionLevel.EncryptionAndAuthentication
+          : DevicePairingProtectionLevel.Encryption)
       : protectionLevel;
 
     if (typeof callback === 'function') {
@@ -513,7 +539,13 @@ class Noble extends NobleEventEmitter {
       this.emit(`pair:${identifier}`, err);
       return;
     }
-    this._bindings.pair(identifier, pairingKind, pairingProtectionLevel);
+    if (hasPin) {
+      // Keep the established PIN-specific binding shape compatible with
+      // native addons built before the general custom-pairing API landed.
+      this._bindings.pair(identifier, pin);
+    } else {
+      this._bindings.pair(identifier, pairingKind, pairingProtectionLevel);
+    }
   }
 
   async pairAsync (idOrAddress, kind, protectionLevel) {

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -57,19 +57,31 @@ class Peripheral extends NobleEventEmitter {
     });
   }
 
-  pair (callback) {
+  isPaired () {
+    return this._noble.isPaired(this.id);
+  }
+
+  pair (options, callback) {
+    if (typeof options === 'function') {
+      callback = options;
+      options = undefined;
+    }
     // Delegate the callback to Noble#pair so it is released via the internal
     // pair:${id} event. Noble#_onPair always emits pair:${id} (even when this
     // peripheral has been removed from Noble's map during cleanup), whereas it
     // only emits this peripheral's 'pair' event while still tracked. Registering
     // on the peripheral event would therefore leave the callback hanging if
     // pairing completes after the peripheral is gone.
-    this._noble.pair(this.id, callback);
+    if (options === undefined) {
+      this._noble.pair(this.id, callback);
+    } else {
+      this._noble.pair(this.id, options, callback);
+    }
   }
 
-  async pairAsync () {
+  async pairAsync (options) {
     return new Promise((resolve, reject) => {
-      this.pair(error => error ? reject(error) : resolve());
+      this.pair(options, error => error ? reject(error) : resolve());
     });
   }
 

--- a/lib/peripheral.js
+++ b/lib/peripheral.js
@@ -57,6 +57,10 @@ class Peripheral extends NobleEventEmitter {
     });
   }
 
+  isPaired () {
+    return this._noble.isPaired(this.id);
+  }
+
   pair (kind, protectionLevel, callback) {
     // Backward compat: `peripheral.pair(callback)` — the legacy signature
     // passes the callback in the 1st position. Detect that and forward

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -388,7 +388,25 @@ void BLEManager::OnMaxPduSizeChanged(GattSession session, winrt::Windows::Founda
     mEmit.MTU(uuid, mtu);
 }
 
-bool BLEManager::Pair(const std::string& uuid)
+bool BLEManager::IsPaired(const std::string& uuid)
+{
+    auto it = mDeviceMap.find(uuid);
+    if (it == mDeviceMap.end() || !it->second.device.has_value())
+    {
+        return false;
+    }
+
+    try
+    {
+        return it->second.device->DeviceInformation().Pairing().IsPaired();
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
+bool BLEManager::Pair(const std::string& uuid, const std::string& pin)
 {
     using winrt::Windows::Devices::Enumeration::DevicePairingKinds;
 
@@ -435,19 +453,12 @@ bool BLEManager::Pair(const std::string& uuid)
             return true;
         }
 
-        // Use custom pairing so we can auto-accept the ConfirmOnly (Just Works)
-        // ceremony without a UI prompt. The actual kind the device requests is
-        // logged so we can diagnose failures.
-        //
-        // The PairingRequested handler must Accept() the args exactly once for
-        // ConfirmOnly; for any other kind (DisplayPin / ProvidePassword /
-        // ConfirmPinMatch etc.) we simply return without Accept(), which Windows
-        // treats as a rejection and the PairAsync completes with the appropriate
-        // failure status (RejectedByHandler / AuthenticationNotAllowed). We have
-        // no UI to surface a PIN or password prompt from this library.
+        // Preserve the existing ConfirmOnly (Just Works) behavior when no PIN
+        // is supplied. A supplied PIN additionally enables authenticated
+        // ProvidePin and ConfirmPinMatch ceremonies.
         custom = pairing.Custom();
         token = custom.PairingRequested(
-            [](winrt::Windows::Devices::Enumeration::DeviceInformationCustomPairing const&,
+            [pin](winrt::Windows::Devices::Enumeration::DeviceInformationCustomPairing const&,
             winrt::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs const& args) {
                 auto kind = args.PairingKind();
                 LOGE("pairing requested, kind=%d", static_cast<int>(kind));
@@ -455,13 +466,29 @@ bool BLEManager::Pair(const std::string& uuid)
                 {
                     args.Accept();
                 }
-                // Any other kind: do not call Accept() — Windows treats the
-                // handler returning as a rejection.
+                else if (!pin.empty() && kind == DevicePairingKinds::ProvidePin)
+                {
+                    args.Accept(winrt::to_hstring(pin));
+                }
+                else if (!pin.empty() && kind == DevicePairingKinds::ConfirmPinMatch &&
+                         winrt::to_string(args.Pin()) == pin)
+                {
+                    args.Accept();
+                }
             });
         handlerRegistered = true;
         auto completed = bind2(this, &BLEManager::OnPaired, uuid, token, custom);
-        custom.PairAsync(DevicePairingKinds::ConfirmOnly, DevicePairingProtectionLevel::Encryption)
-            .Completed(completed);
+        auto requestedKinds = DevicePairingKinds::ConfirmOnly;
+        auto protectionLevel = DevicePairingProtectionLevel::Encryption;
+        if (!pin.empty())
+        {
+            requestedKinds = static_cast<DevicePairingKinds>(
+                static_cast<uint32_t>(DevicePairingKinds::ConfirmOnly) |
+                static_cast<uint32_t>(DevicePairingKinds::ProvidePin) |
+                static_cast<uint32_t>(DevicePairingKinds::ConfirmPinMatch));
+            protectionLevel = DevicePairingProtectionLevel::EncryptionAndAuthentication;
+        }
+        custom.PairAsync(requestedKinds, protectionLevel).Completed(completed);
     }
     catch (const winrt::hresult_error& e)
     {

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -388,9 +388,28 @@ void BLEManager::OnMaxPduSizeChanged(GattSession session, winrt::Windows::Founda
     mEmit.MTU(uuid, mtu);
 }
 
+bool BLEManager::IsPaired(const std::string& uuid)
+{
+    auto it = mDeviceMap.find(uuid);
+    if (it == mDeviceMap.end() || !it->second.device.has_value())
+    {
+        return false;
+    }
+
+    try
+    {
+        return it->second.device->DeviceInformation().Pairing().IsPaired();
+    }
+    catch (...)
+    {
+        return false;
+    }
+}
+
 bool BLEManager::Pair(const std::string& uuid,
                       winrt::Windows::Devices::Enumeration::DevicePairingKinds kinds,
-                      winrt::Windows::Devices::Enumeration::DevicePairingProtectionLevel protectionLevel)
+                      winrt::Windows::Devices::Enumeration::DevicePairingProtectionLevel protectionLevel,
+                      const std::string& pin)
 {
     auto it = mDeviceMap.find(uuid);
     if (it == mDeviceMap.end() || !it->second.device.has_value())
@@ -435,23 +454,33 @@ bool BLEManager::Pair(const std::string& uuid,
             return true;
         }
 
-        // These ceremony values are not supported because this library does
-        // not collect PIN/password input to forward into an Accept(...) overload.
-        constexpr uint32_t unsupportedKinds =
-            0x00000040u | 0x00000080u | 0x00000100u;
-        if ((static_cast<uint32_t>(kinds) & unsupportedKinds) != 0)
+        if (!pin.empty())
+        {
+            protectionLevel = DevicePairingProtectionLevel::EncryptionAndAuthentication;
+        }
+
+        // Password ceremonies remain unsupported. ProvidePin is supported only
+        // when the caller supplied the secret through PairOptions.
+        constexpr uint32_t passwordKinds = 0x00000080u | 0x00000100u;
+        auto requestedKinds = static_cast<uint32_t>(kinds);
+        if ((requestedKinds & passwordKinds) != 0)
         {
             mEmit.Paired(uuid, false,
-                         "pairing kinds requiring a PIN or password are not supported");
+                         "pairing kinds requiring a password are not supported");
+            return true;
+        }
+        if ((requestedKinds & static_cast<uint32_t>(DevicePairingKinds::ProvidePin)) != 0 &&
+            pin.empty())
+        {
+            mEmit.Paired(uuid, false, "ProvidePin pairing requires a PIN");
             return true;
         }
 
         // Always go through `pairing.Custom()`: only DeviceInformationCustomPairing
         // accepts a `DevicePairingKinds` mask (DeviceInformationPairing.PairAsync
         // takes only a protection level). The caller-supplied `kinds` may
-        // include ConfirmOnly, DisplayPin, or ConfirmPinMatch; PIN/password
-        // ceremonies are rejected before we get here because this library does
-        // not provide a way to collect or forward secrets to Accept(...).
+        // include the UI-backed ceremonies plus ProvidePin when a caller has
+        // supplied the secret. Password ceremonies are rejected above.
         //
         // The PairingRequested lambda must Accept() exactly once for any kind
         // the caller advertised in `kinds`. Some devices negotiated through
@@ -459,12 +488,11 @@ bool BLEManager::Pair(const std::string& uuid,
         // compatible fallback so pairing does not fail with status=Failed.
         // For other kinds outside the mask we return without Accept(), which
         // Windows treats as a rejection and PairAsync completes with
-        // RejectedByHandler / AuthenticationNotAllowed. We never forward a PIN
-        // or password back to JS — Windows drives the UI for non-ConfirmOnly
-        // ceremonies.
+        // RejectedByHandler / AuthenticationNotAllowed. Caller-provided PINs
+        // are used only for ProvidePin and to verify ConfirmPinMatch.
         custom = pairing.Custom();
         token = custom.PairingRequested(
-            [kinds](winrt::Windows::Devices::Enumeration::DeviceInformationCustomPairing const&,
+            [kinds, pin](winrt::Windows::Devices::Enumeration::DeviceInformationCustomPairing const&,
                 winrt::Windows::Devices::Enumeration::DevicePairingRequestedEventArgs const& args) {
                 auto kind = args.PairingKind();
                 auto kindMask = static_cast<uint32_t>(kind);
@@ -477,6 +505,23 @@ bool BLEManager::Pair(const std::string& uuid,
                     confirmPinMatchRequested &&
                     kind == winrt::Windows::Devices::Enumeration::DevicePairingKinds::ConfirmOnly;
                 LOGE("pairing requested, kind=%d", static_cast<int>(kind));
+                if (kind == DevicePairingKinds::ProvidePin)
+                {
+                    if (!pin.empty() && (kindMask & requestedKinds) != 0)
+                    {
+                        args.Accept(winrt::to_hstring(pin));
+                    }
+                    return;
+                }
+                if (kind == DevicePairingKinds::ConfirmPinMatch && !pin.empty())
+                {
+                    if ((kindMask & requestedKinds) != 0 &&
+                        winrt::to_string(args.Pin()) == pin)
+                    {
+                        args.Accept();
+                    }
+                    return;
+                }
                 if ((kindMask & requestedKinds) != 0 || confirmOnlyFallback)
                 {
                     args.Accept();

--- a/lib/win/src/ble_manager.cc
+++ b/lib/win/src/ble_manager.cc
@@ -221,7 +221,11 @@ void BLEManager::OnScanResult(BluetoothLEAdvertisementWatcher watcher,
             }
         }
 
-        if (!found) {
+        // Windows reports the scan response separately from the advertising
+        // packet. Once a device has matched the service filter, keep its
+        // follow-up packets so Complete Local Name and other scan-response
+        // fields can update the existing Peripheral.
+        if (!found && mDeviceMap.find(uuid) == mDeviceMap.end()) {
             return;
         }
     }

--- a/lib/win/src/ble_manager.h
+++ b/lib/win/src/ble_manager.h
@@ -22,7 +22,8 @@ public:
     void Scan(const std::vector<winrt::guid>& serviceUUIDs, bool allowDuplicates);
     void StopScan();
     bool Connect(const std::string& uuid);
-    bool Pair(const std::string& uuid);
+    bool IsPaired(const std::string& uuid);
+    bool Pair(const std::string& uuid, const std::string& pin = "");
     bool Disconnect(const std::string& uuid);
     bool CancelConnect(const std::string& uuid);
     bool UpdateRSSI(const std::string& uuid);

--- a/lib/win/src/ble_manager.h
+++ b/lib/win/src/ble_manager.h
@@ -22,10 +22,12 @@ public:
     void Scan(const std::vector<winrt::guid>& serviceUUIDs, bool allowDuplicates);
     void StopScan();
     bool Connect(const std::string& uuid);
+    bool IsPaired(const std::string& uuid);
     bool Pair(
         const std::string& uuid,
         winrt::Windows::Devices::Enumeration::DevicePairingKinds kinds,
-        winrt::Windows::Devices::Enumeration::DevicePairingProtectionLevel protectionLevel);
+        winrt::Windows::Devices::Enumeration::DevicePairingProtectionLevel protectionLevel,
+        const std::string& pin = "");
     bool Disconnect(const std::string& uuid);
     bool CancelConnect(const std::string& uuid);
     bool UpdateRSSI(const std::string& uuid);

--- a/lib/win/src/noble_winrt.cc
+++ b/lib/win/src/noble_winrt.cc
@@ -101,13 +101,31 @@ Napi::Value NobleWinrt::Connect(const Napi::CallbackInfo& info)
     return info.Env().Undefined();
 }
 
-// pair(deviceUuid)
+// isPaired(deviceUuid)
+Napi::Value NobleWinrt::IsPaired(const Napi::CallbackInfo& info)
+{
+    CHECK_MANAGER()
+    ARG1(String)
+    auto uuid = info[0].As<Napi::String>().Utf8Value();
+    return Napi::Boolean::New(info.Env(), manager->IsPaired(uuid));
+}
+
+// pair(deviceUuid, pin?)
 Napi::Value NobleWinrt::Pair(const Napi::CallbackInfo& info)
 {
     CHECK_MANAGER()
     ARG1(String)
     auto uuid = info[0].As<Napi::String>().Utf8Value();
-    manager->Pair(uuid);
+    std::string pin;
+    if (info.Length() > 1 && !info[1].IsUndefined())
+    {
+        if (!info[1].IsString())
+        {
+            THROW("The optional PIN argument must be a string")
+        }
+        pin = info[1].As<Napi::String>().Utf8Value();
+    }
+    manager->Pair(uuid, pin);
     return info.Env().Undefined();
 }
 
@@ -325,6 +343,7 @@ Napi::Object NobleWinrt::Init(Napi::Env env, Napi::Object exports) {
         NobleWinrt::InstanceMethod("startScanning", &NobleWinrt::Scan),
         NobleWinrt::InstanceMethod("stopScanning", &NobleWinrt::StopScan),
         NobleWinrt::InstanceMethod("connect", &NobleWinrt::Connect),
+        NobleWinrt::InstanceMethod("isPaired", &NobleWinrt::IsPaired),
         NobleWinrt::InstanceMethod("pair", &NobleWinrt::Pair),
         NobleWinrt::InstanceMethod("disconnect", &NobleWinrt::Disconnect),
         NobleWinrt::InstanceMethod("cancelConnect", &NobleWinrt::CancelConnect),

--- a/lib/win/src/noble_winrt.cc
+++ b/lib/win/src/noble_winrt.cc
@@ -101,28 +101,56 @@ Napi::Value NobleWinrt::Connect(const Napi::CallbackInfo& info)
     return info.Env().Undefined();
 }
 
-// pair(deviceUuid, kinds?, protectionLevel?)
+// isPaired(deviceUuid)
+Napi::Value NobleWinrt::IsPaired(const Napi::CallbackInfo& info)
+{
+    CHECK_MANAGER()
+    ARG1(String)
+    auto uuid = info[0].As<Napi::String>().Utf8Value();
+    return Napi::Boolean::New(info.Env(), manager->IsPaired(uuid));
+}
+
+// pair(deviceUuid, pin?) or pair(deviceUuid, kinds?, protectionLevel?, pin?)
 Napi::Value NobleWinrt::Pair(const Napi::CallbackInfo& info)
 {
     CHECK_MANAGER()
     ARG1(String)
     auto uuid = info[0].As<Napi::String>().Utf8Value();
 
-    // `kinds` is a DevicePairingKinds bitmask. The JS layer (noble.js) is
-    // expected to normalize the value before forwarding here — including
-    // rejecting DevicePairingKinds.None — so any default we pick is a
-    // belt-and-suspenders backstop, not a primary code path. We default
-    // to None (0) rather than ConfirmOnly to surface unexpected callers
-    // via the lambda's `(kind & kinds) == 0` check (PairAsync will fail
-    // with RejectedByHandler), instead of silently falling through to a
-    // ceremony the caller never asked for.
     using winrt::Windows::Devices::Enumeration::DevicePairingKinds;
     using winrt::Windows::Devices::Enumeration::DevicePairingProtectionLevel;
-    auto kinds = static_cast<DevicePairingKinds>(
-        getUint32(info[1], static_cast<uint32_t>(DevicePairingKinds::None)));
-    auto protectionLevel = static_cast<DevicePairingProtectionLevel>(
-        getUint32(info[2], static_cast<uint32_t>(DevicePairingProtectionLevel::Encryption)));
-    manager->Pair(uuid, kinds, protectionLevel);
+    auto kinds = DevicePairingKinds::ConfirmOnly;
+    auto protectionLevel = DevicePairingProtectionLevel::Encryption;
+    std::string pin;
+
+    // Preserve the PIN-specific binding ABI used by existing prebuilds and
+    // callers: pair(deviceUuid, pin). The general API uses the numeric WinRT
+    // kind/protection arguments instead.
+    if (info.Length() > 1 && info[1].IsString())
+    {
+        pin = info[1].As<Napi::String>().Utf8Value();
+        kinds = static_cast<DevicePairingKinds>(
+            static_cast<uint32_t>(DevicePairingKinds::ConfirmOnly) |
+            static_cast<uint32_t>(DevicePairingKinds::ProvidePin) |
+            static_cast<uint32_t>(DevicePairingKinds::ConfirmPinMatch));
+        protectionLevel = DevicePairingProtectionLevel::EncryptionAndAuthentication;
+    }
+    else if (info.Length() > 1)
+    {
+        kinds = static_cast<DevicePairingKinds>(
+            getUint32(info[1], static_cast<uint32_t>(DevicePairingKinds::None)));
+        protectionLevel = static_cast<DevicePairingProtectionLevel>(
+            getUint32(info[2], static_cast<uint32_t>(DevicePairingProtectionLevel::Encryption)));
+        if (info.Length() > 3 && !info[3].IsUndefined())
+        {
+            if (!info[3].IsString())
+            {
+                THROW("The optional PIN argument must be a string")
+            }
+            pin = info[3].As<Napi::String>().Utf8Value();
+        }
+    }
+    manager->Pair(uuid, kinds, protectionLevel, pin);
     return info.Env().Undefined();
 }
 
@@ -340,6 +368,7 @@ Napi::Object NobleWinrt::Init(Napi::Env env, Napi::Object exports) {
         NobleWinrt::InstanceMethod("startScanning", &NobleWinrt::Scan),
         NobleWinrt::InstanceMethod("stopScanning", &NobleWinrt::StopScan),
         NobleWinrt::InstanceMethod("connect", &NobleWinrt::Connect),
+        NobleWinrt::InstanceMethod("isPaired", &NobleWinrt::IsPaired),
         NobleWinrt::InstanceMethod("pair", &NobleWinrt::Pair),
         NobleWinrt::InstanceMethod("disconnect", &NobleWinrt::Disconnect),
         NobleWinrt::InstanceMethod("cancelConnect", &NobleWinrt::CancelConnect),

--- a/lib/win/src/noble_winrt.h
+++ b/lib/win/src/noble_winrt.h
@@ -13,6 +13,7 @@ public:
     Napi::Value Scan(const Napi::CallbackInfo&);
     Napi::Value StopScan(const Napi::CallbackInfo&);
     Napi::Value Connect(const Napi::CallbackInfo&);
+    Napi::Value IsPaired(const Napi::CallbackInfo&);
     Napi::Value Pair(const Napi::CallbackInfo&);
     Napi::Value Disconnect(const Napi::CallbackInfo&);
     Napi::Value CancelConnect(const Napi::CallbackInfo&);

--- a/test/lib/peripheral.test.js
+++ b/test/lib/peripheral.test.js
@@ -178,10 +178,27 @@ describe('peripheral', () => {
   });
 
   describe('pair', () => {
+    test('should delegate pairing-state checks to noble', () => {
+      mockNoble.isPaired = jest.fn(() => true);
+
+      expect(peripheral.isPaired()).toBe(true);
+      expect(mockNoble.isPaired).toHaveBeenCalledWith(mockId);
+    });
+
     test('should delegate to noble, forwarding the callback', () => {
       peripheral.pair();
 
       expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined);
+      expect(mockNoble.pair).toHaveBeenCalledTimes(1);
+    });
+
+    test('should delegate options and callback to noble', () => {
+      const options = { pin: '123456' };
+      const callback = jest.fn();
+
+      peripheral.pair(options, callback);
+
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, options, callback);
       expect(mockNoble.pair).toHaveBeenCalledTimes(1);
     });
 
@@ -235,6 +252,16 @@ describe('peripheral', () => {
 
       await expect(promise).resolves.toBeUndefined();
       expect(mockNoble.pair).toHaveBeenCalledWith(mockId, expect.any(Function));
+      expect(mockNoble.pair).toHaveBeenCalledTimes(1);
+    });
+
+    test('should delegate options', async () => {
+      const options = { pin: '123456' };
+      const promise = peripheral.pairAsync(options);
+      mockNoble.pair.mock.calls[0][2](null);
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, options, expect.any(Function));
       expect(mockNoble.pair).toHaveBeenCalledTimes(1);
     });
 

--- a/test/lib/peripheral.test.js
+++ b/test/lib/peripheral.test.js
@@ -178,10 +178,27 @@ describe('peripheral', () => {
   });
 
   describe('pair', () => {
+    test('should delegate pairing-state checks to noble', () => {
+      mockNoble.isPaired = jest.fn(() => true);
+
+      expect(peripheral.isPaired()).toBe(true);
+      expect(mockNoble.isPaired).toHaveBeenCalledWith(mockId);
+    });
+
     test('should delegate to noble, forwarding the callback', () => {
       peripheral.pair();
 
       expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, undefined, undefined);
+      expect(mockNoble.pair).toHaveBeenCalledTimes(1);
+    });
+
+    test('should delegate options and callback to noble', () => {
+      const options = { pin: '123456' };
+      const callback = jest.fn();
+
+      peripheral.pair(options, callback);
+
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, options, undefined, callback);
       expect(mockNoble.pair).toHaveBeenCalledTimes(1);
     });
 
@@ -259,6 +276,16 @@ describe('peripheral', () => {
 
       await expect(promise).resolves.toBeUndefined();
       expect(mockNoble.pair).toHaveBeenCalledWith(mockId, undefined, undefined, expect.any(Function));
+      expect(mockNoble.pair).toHaveBeenCalledTimes(1);
+    });
+
+    test('should delegate options', async () => {
+      const options = { pin: '123456' };
+      const promise = peripheral.pairAsync(options);
+      mockNoble.pair.mock.calls[0][3](null);
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(mockNoble.pair).toHaveBeenCalledWith(mockId, options, undefined, expect.any(Function));
       expect(mockNoble.pair).toHaveBeenCalledTimes(1);
     });
 

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -667,6 +667,18 @@ describe('noble', () => {
   });
 
   describe('pair', () => {
+    test('should report pairing state exposed by the binding', () => {
+      const peripheralUuid = 'aabbccddeeff';
+      mockBindings.isPaired = jest.fn(() => true);
+
+      expect(noble.isPaired(peripheralUuid)).toBe(true);
+      expect(mockBindings.isPaired).toHaveBeenCalledWith(peripheralUuid);
+    });
+
+    test('should report unpaired when the binding has no pairing-state API', () => {
+      expect(noble.isPaired('aabbccddeeff')).toBe(false);
+    });
+
     test('should delegate to binding', () => {
       const peripheralUuid = 'aabbccddeeff';
 
@@ -674,6 +686,16 @@ describe('noble', () => {
       noble.pair(peripheralUuid);
 
       expect(mockBindings.pair).toHaveBeenCalledWith(peripheralUuid);
+      expect(mockBindings.pair).toHaveBeenCalledTimes(1);
+    });
+
+    test('should delegate a PIN to the binding', () => {
+      const peripheralUuid = 'aabbccddeeff';
+
+      mockBindings.pair = jest.fn();
+      noble.pair(peripheralUuid, { pin: '123456' });
+
+      expect(mockBindings.pair).toHaveBeenCalledWith(peripheralUuid, '123456');
       expect(mockBindings.pair).toHaveBeenCalledTimes(1);
     });
 
@@ -715,6 +737,18 @@ describe('noble', () => {
 
       await expect(promise).resolves.toBeUndefined();
       expect(mockBindings.pair).toHaveBeenCalledWith(peripheralUuid);
+    });
+
+    test('should delegate options', async () => {
+      const peripheralUuid = 'aabbccddeeff';
+      mockBindings.pair = jest.fn();
+      noble._peripherals.set(peripheralUuid, { emit: jest.fn() });
+
+      const promise = noble.pairAsync(peripheralUuid, { pin: '123456' });
+      noble._onPair(peripheralUuid, true);
+
+      await expect(promise).resolves.toBeUndefined();
+      expect(mockBindings.pair).toHaveBeenCalledWith(peripheralUuid, '123456');
     });
 
     test('should reject on failure', async () => {

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -642,6 +642,7 @@ describe('noble', () => {
       None: 0,
       ConfirmOnly: 0x00000008,
       DisplayPin: 0x00000010,
+      ConfirmPinMatch: 0x00000020,
       ProvidePin: 0x00000040,
     };
     const DevicePairingProtectionLevel = {
@@ -654,6 +655,17 @@ describe('noble', () => {
     // mocked addressToId (whose return value would otherwise become the
     // forwarded identifier).
     const peripheralUuidHex = '00112233445566778899aabbccddeeff';
+
+    test('should report pairing state exposed by the binding', () => {
+      mockBindings.isPaired = jest.fn(() => true);
+
+      expect(noble.isPaired(peripheralUuidHex)).toBe(true);
+      expect(mockBindings.isPaired).toHaveBeenCalledWith(peripheralUuidHex);
+    });
+
+    test('should report unpaired when the binding has no pairing-state API', () => {
+      expect(noble.isPaired(peripheralUuidHex)).toBe(false);
+    });
 
     test('should default to ConfirmOnly when kind is omitted', () => {
       mockBindings.pair = jest.fn();
@@ -699,6 +711,28 @@ describe('noble', () => {
         DevicePairingKinds.ConfirmOnly,
         DevicePairingProtectionLevel.EncryptionAndAuthentication
       );
+    });
+
+    test('should derive authenticated pairing defaults from a PIN option', () => {
+      mockBindings.pair = jest.fn();
+      noble.pair(peripheralUuidHex, { pin: '123456' });
+
+      expect(mockBindings.pair).toHaveBeenCalledWith(
+        peripheralUuidHex,
+        '123456'
+      );
+    });
+
+    test('should reject a non-string PIN', () => {
+      mockBindings.pair = jest.fn();
+      const cb = jest.fn();
+
+      noble.pair(peripheralUuidHex, { pin: 123456 }, cb);
+
+      expect(cb).toHaveBeenCalledWith(expect.objectContaining({
+        message: 'pair() options.pin must be a string'
+      }));
+      expect(mockBindings.pair).not.toHaveBeenCalled();
     });
 
     test('should treat function in 2nd position as callback (legacy signature)', () => {
@@ -765,6 +799,18 @@ describe('noble', () => {
         peripheralUuidHex,
         DevicePairingKinds.ProvidePin,
         DevicePairingProtectionLevel.None
+      );
+    });
+
+    test('pairAsync should forward PIN options', async () => {
+      mockBindings.pair = jest.fn();
+      const promise = noble.pairAsync(peripheralUuidHex, { pin: '123456' });
+      noble.emit(`pair:${peripheralUuidHex}`, null);
+
+      await promise;
+      expect(mockBindings.pair).toHaveBeenCalledWith(
+        peripheralUuidHex,
+        '123456'
       );
     });
 


### PR DESCRIPTION
Extend the existing Windows pairing API with optional caller-provided PINs while preserving the current ConfirmOnly behavior for callers that do not pass pairing options.

Expose PairOptions through the Noble and Peripheral callback and async APIs, and add isPaired helpers so applications can avoid prompting users when WinRT already reports a durable bond. Bindings without pairing-state support continue to report false, and unsupported-platform pairing retains its existing deterministic error behavior.

On WinRT, accept ProvidePin requests with the supplied value and accept ConfirmPinMatch only when the displayed PIN matches. PIN-based requests require EncryptionAndAuthentication; calls without a PIN continue to request ConfirmOnly with Encryption exactly as before. Keep PIN values out of logging and retain the existing pairing result and exception handling paths.

Document the platform behavior and add regression coverage for legacy callback signatures, no-option delegation, PIN forwarding, paired-state queries, async options, and Peripheral delegation.