### PR TITLE
fix(dbus): pause discovery for the duration of a connect attempt

### DIFF
--- a/lib/dbus/bindings.js
+++ b/lib/dbus/bindings.js
@@ -148,6 +148,8 @@ class DbusBindings extends EventEmitter {
     this._adapterAddress = 'unknown';
     this._state = 'unknown';
     this._isScanning = false;
+    this._connectsInFlight = 0;
+    this._discoveryDeferredByConnect = false;
 
     // Object tree mirror: path -> { iface: props }
     this._objects = new Map();
@@ -268,9 +270,11 @@ class DbusBindings extends EventEmitter {
     const wasScanning = this._isScanning;
     this._isScanning = false;
     this._unwatchAllDeviceProps();
-    if (wasScanning && this._adapterIface) {
+    if (wasScanning && this._adapterIface && !this._discoveryDeferredByConnect) {
       this._adapterIface.StopDiscovery().catch(() => {});
     }
+    this._connectsInFlight = 0;
+    this._discoveryDeferredByConnect = false;
     if (this._bus && typeof this._bus.disconnect === 'function') {
       try { this._bus.disconnect(); } catch (_) { /* ignore */ }
     }
@@ -309,7 +313,13 @@ class DbusBindings extends EventEmitter {
       debug('SetDiscoveryFilter failed: %s', err.message);
     }
     if (!this._isScanning) {
-      await this._adapterIface.StartDiscovery();
+      if (this._connectsInFlight === 0) {
+        await this._adapterIface.StartDiscovery();
+      } else {
+        // Defer to the connect that owns the adapter; without this the scan would be
+        // recorded as running while BlueZ was never told to start it.
+        this._discoveryDeferredByConnect = true;
+      }
       this._isScanning = true;
     }
 
@@ -351,7 +361,7 @@ class DbusBindings extends EventEmitter {
     // re-attaching a listener that would outlive the scan.
     this._isScanning = false;
     this._unwatchAllDeviceProps();
-    if (wasScanning && this._adapterIface) {
+    if (wasScanning && this._adapterIface && !this._discoveryDeferredByConnect) {
       try {
         await this._adapterIface.StopDiscovery();
       } catch (err) {
@@ -359,6 +369,39 @@ class DbusBindings extends EventEmitter {
       }
     }
     this.emit('scanStop');
+  }
+
+  // BlueZ resumes its own scan as soon as the controller reports the connection, which is
+  // still inside the link layer establishment window. Keep the radio free until the attempt
+  // settles, the way the hci backend serialises scanning against connecting.
+  // _discoveryDeferredByConnect means a scan is owed once the last attempt finishes,
+  // whether this stopped a running one or _startScanning skipped starting it.
+  async _pauseDiscoveryForConnect () {
+    this._connectsInFlight += 1;
+    if (this._connectsInFlight !== 1) return;
+    if (!this._isScanning || !this._adapterIface) return;
+
+    this._discoveryDeferredByConnect = true;
+    try {
+      await this._adapterIface.StopDiscovery();
+    } catch (err) {
+      debug('StopDiscovery for connect failed: %s', err.message);
+    }
+  }
+
+  async _resumeDiscoveryAfterConnect () {
+    this._connectsInFlight = Math.max(0, this._connectsInFlight - 1);
+    if (this._connectsInFlight !== 0 || !this._discoveryDeferredByConnect) return;
+
+    this._discoveryDeferredByConnect = false;
+    // An explicit stopScanning() during the attempt cleared _isScanning and must still win.
+    if (!this._isScanning || !this._adapterIface) return;
+
+    try {
+      await this._adapterIface.StartDiscovery();
+    } catch (err) {
+      debug('StartDiscovery after connect failed: %s', err.message);
+    }
   }
 
   // ---- ObjectManager + property change handlers ----
@@ -609,17 +652,24 @@ class DbusBindings extends EventEmitter {
       return;
     }
 
-    const waitConnected = new Promise((resolve, reject) => {
-      device.connectPromise = { resolve, reject };
-    });
-
-    // Keep both in one await: split into sequential awaits and a mid-connect
-    // remote drop rejects waitConnected with no handler yet, crashing the process.
+    // Pause before connectPromise exists: a remote drop landing while this awaits would
+    // otherwise reject waitConnected with no handler attached yet.
+    await this._pauseDiscoveryForConnect();
     try {
-      await Promise.all([iface.Connect(), waitConnected]);
-    } catch (err) {
-      device.connectPromise = null;
-      throw err;
+      const waitConnected = new Promise((resolve, reject) => {
+        device.connectPromise = { resolve, reject };
+      });
+
+      // Keep both in one await: split into sequential awaits and a mid-connect
+      // remote drop rejects waitConnected with no handler yet, crashing the process.
+      try {
+        await Promise.all([iface.Connect(), waitConnected]);
+      } catch (err) {
+        device.connectPromise = null;
+        throw err;
+      }
+    } finally {
+      await this._resumeDiscoveryAfterConnect();
     }
 
     this.emit('connect', id, null);

--- a/test/lib/dbus/bindings.test.js
+++ b/test/lib/dbus/bindings.test.js
@@ -724,6 +724,174 @@ describe('dbus/bindings', () => {
     });
   });
 
+  describe('discovery is paused while connecting', () => {
+    const devicePath = '/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF';
+    const otherPath = '/org/bluez/hci0/dev_11_22_33_44_55_66';
+
+    function seedDevices () {
+      resetState(adapterTree({
+        [devicePath]: {
+          'org.bluez.Device1': { Address: 'AA:BB:CC:DD:EE:FF', AddressType: 'public', Connected: false }
+        },
+        [otherPath]: {
+          'org.bluez.Device1': { Address: '11:22:33:44:55:66', AddressType: 'public', Connected: false }
+        }
+      }));
+    }
+
+    const adapterMethods = () => state.ifaceCalls
+      .filter(c => c.iface === 'org.bluez.Adapter1')
+      .map(c => c.method);
+
+    async function startScanning (bindings) {
+      bindings.start();
+      await flush();
+      bindings.startScanning([], false);
+      await flush();
+      state.ifaceCalls.length = 0;
+    }
+
+    // Resolves the connect the way BlueZ does: Connected + ServicesResolved.
+    function completeConnect (path) {
+      makeProxy(path)
+        .getInterface('org.freedesktop.DBus.Properties')
+        .emit('PropertiesChanged', 'org.bluez.Device1', wrapDict({ Connected: true, ServicesResolved: true }));
+    }
+
+    test('stops discovery before Connect and restarts it once the attempt succeeds', async () => {
+      seedDevices();
+      const bindings = new DbusBindings();
+      await startScanning(bindings);
+
+      bindings.connect('aabbccddeeff');
+      await flush();
+
+      expect(adapterMethods()).toEqual(['StopDiscovery']);
+
+      completeConnect(devicePath);
+      await flush();
+
+      expect(adapterMethods()).toEqual(['StopDiscovery', 'StartDiscovery']);
+      expect(bindings._isScanning).toBe(true);
+    });
+
+    test('restarts discovery when the attempt fails', async () => {
+      seedDevices();
+      makeProxy(devicePath).getInterface('org.bluez.Device1').Connect =
+        () => Promise.reject(new Error('le-connection-abort-by-local'));
+
+      const bindings = new DbusBindings();
+      const connects = [];
+      bindings.on('connect', (id, err) => connects.push([id, err]));
+      await startScanning(bindings);
+
+      bindings.connect('aabbccddeeff');
+      await flush();
+
+      expect(connects[0][1]).toBeInstanceOf(Error);
+      expect(adapterMethods()).toEqual(['StopDiscovery', 'StartDiscovery']);
+    });
+
+    test('does not touch discovery when no scan is running', async () => {
+      seedDevices();
+      const bindings = new DbusBindings();
+      bindings.start();
+      await flush();
+      state.ifaceCalls.length = 0;
+
+      bindings.connect('aabbccddeeff');
+      await flush();
+      completeConnect(devicePath);
+      await flush();
+
+      expect(adapterMethods()).toEqual([]);
+    });
+
+    test('parallel connects stop discovery once and restart it after the last one', async () => {
+      seedDevices();
+      const bindings = new DbusBindings();
+      await startScanning(bindings);
+
+      bindings.connect('aabbccddeeff');
+      bindings.connect('112233445566');
+      await flush();
+
+      expect(adapterMethods()).toEqual(['StopDiscovery']);
+
+      completeConnect(devicePath);
+      await flush();
+      expect(adapterMethods()).toEqual(['StopDiscovery']);
+
+      completeConnect(otherPath);
+      await flush();
+      expect(adapterMethods()).toEqual(['StopDiscovery', 'StartDiscovery']);
+    });
+
+    test('an explicit stopScanning during a connect wins over the resume', async () => {
+      seedDevices();
+      const bindings = new DbusBindings();
+      await startScanning(bindings);
+
+      bindings.connect('aabbccddeeff');
+      await flush();
+      expect(adapterMethods()).toEqual(['StopDiscovery']);
+
+      bindings.stopScanning();
+      await flush();
+      completeConnect(devicePath);
+      await flush();
+
+      // No second StopDiscovery (already paused) and no resume of a scan the caller ended.
+      expect(adapterMethods()).toEqual(['StopDiscovery']);
+      expect(bindings._isScanning).toBe(false);
+    });
+
+    test('a first scan started during a connect still reaches BlueZ once the connect ends', async () => {
+      seedDevices();
+      const bindings = new DbusBindings();
+      bindings.start();
+      await flush();
+      state.ifaceCalls.length = 0;
+
+      // Connect while no scan is running, so nothing is paused.
+      bindings.connect('aabbccddeeff');
+      await flush();
+      expect(adapterMethods()).toEqual([]);
+
+      bindings.startScanning([], false);
+      await flush();
+      expect(adapterMethods()).toEqual(['SetDiscoveryFilter']);
+      expect(bindings._isScanning).toBe(true);
+
+      completeConnect(devicePath);
+      await flush();
+
+      // Without the deferral the scan would be reported as running but never started.
+      expect(adapterMethods()).toEqual(['SetDiscoveryFilter', 'StartDiscovery']);
+    });
+
+    test('a startScanning during a connect defers StartDiscovery to the resume', async () => {
+      seedDevices();
+      const bindings = new DbusBindings();
+      await startScanning(bindings);
+
+      bindings.connect('aabbccddeeff');
+      await flush();
+      bindings.stopScanning();
+      await flush();
+      bindings.startScanning([], false);
+      await flush();
+
+      expect(adapterMethods()).toEqual(['StopDiscovery', 'SetDiscoveryFilter']);
+      expect(bindings._isScanning).toBe(true);
+
+      completeConnect(devicePath);
+      await flush();
+
+      expect(adapterMethods()).toEqual(['StopDiscovery', 'SetDiscoveryFilter', 'StartDiscovery']);
+    });
+  });
+
   describe('late-arriving advertisement data during scan', () => {
     const devicePath = '/org/bluez/hci0/dev_AA_BB_CC_DD_EE_FF';
 


### PR DESCRIPTION
Implements the proposal from #136: the dbus backend now serialises scanning against connecting the way the hci backend already does in `processConnectionQueue`.

Discovery is stopped when the first connect attempt starts and restarted when the last one finishes, so several concurrent connects cost one stop and one start rather than one pair each. The restore runs from a `finally`, so a rejected or hanging `Connect()` cannot leave discovery switched off.

**Please read the scope claim carefully before merging.** I am *not* claiming this fixes the `0x3e` connection failures from matter-js/matterjs-server#929. A capture from the hci backend shows the same status with scanning explicitly disabled, so that peripheral fails to complete establishment regardless of scan state, and what rescues the hci path is its retry. Resuming a 100% duty cycle active scan five milliseconds into the link layer establishment window on a single radio controller is a plausible aggravator and the two backends should not differ here, but the causal claim is not mine to make on the evidence I have. That is why the commit says `Refs #136` and not `Fixes`.

All three constraints from the issue are respected:

1. **Reference counted.** `_connectsInFlight` gates the stop and the restart, since this backend has no connection queue and callers do connect to several peripherals at once.
2. **Restored on every exit path**, via `finally`.
3. **Quiet.** The pause calls `StopDiscovery`/`StartDiscovery` directly rather than going through `_stopScanning`/`_startScanning`, which would flip `_isScanning`, drop every device property watcher, re-run `GetManagedObjects()` and emit `scanStop`/`scanStart` around every connect. Consumers would read that as a full scan restart and re-surface every cached device.

Two details worth a look during review:

- **The pause runs before `device.connectPromise` exists.** Awaiting a D-Bus round trip after storing it would let a remote drop reject it with no handler attached yet — the unhandled rejection fixed in #91/#92. There is already a regression test for that window and it still passes.
- **`_startScanning` records intent while an attempt owns the adapter** and lets the resume issue the command. Without that branch a scan begun during a connect would set `_isScanning = true` and emit `scanStart` while BlueZ was never told to start, and no `discover` events would arrive until an unrelated stop/start cycle. An adversarial review of my own first draft caught exactly that, so there is a named test for it.

An explicit `stopScanning()` during an attempt still wins over the restore.

Tests: 7 new cases covering pause before connect and restart after success, restart after failure, no discovery calls when no scan is running, one stop and one start across parallel connects, an explicit stop winning over the resume, a scan started mid-connect reaching BlueZ afterwards, and a first-ever scan started mid-connect. I checked each production hunk by reverting it and confirming a named test fails, so none of them pass vacuously.

Local full suite: 19 suites, 829 passed, 1 expected skip. Lint clean.

Not verified on hardware — I have no BlueZ setup with the affected peripheral. The behaviour is covered by the D-Bus mock only, so a sanity run on a real adapter before release would be worth it.

Refs #136
