### PR TITLE
fix(gatt): honour the requested ATT MTU, and declare it as a connect option

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -61,6 +61,16 @@ declare module '@stoprocent/noble' {
         maxInterval?: number;
         latency?: number;
         timeout?: number;
+        /**
+         * Client RX MTU to request in the ATT exchange. Must be an integer from 23
+         * to 517; anything else is ignored and the 256 default is requested instead.
+         * The negotiated ATT MTU is the lower of this and the peripheral's, and is
+         * reported by the peripheral's `mtu` event.
+         *
+         * HCI bindings only. CoreBluetooth, WinRT and BlueZ negotiate the MTU
+         * themselves and expose it read-only, so there is nothing to request.
+         */
+        mtu?: number;
     }
 
     export class Noble extends EventEmitter {
@@ -151,7 +161,7 @@ declare module '@stoprocent/noble' {
         /** @deprecated Use id instead */
         readonly uuid: string;
     
-        connectAsync(): Promise<void>;
+        connectAsync(options?: ConnectOptions): Promise<void>;
         pairAsync(kind?: DevicePairingKinds, protectionLevel?: DevicePairingProtectionLevel): Promise<void>;
         disconnectAsync(): Promise<void>;
         updateRssiAsync(): Promise<number>;
@@ -163,6 +173,7 @@ declare module '@stoprocent/noble' {
         writeHandleAsync(handle: number, data: Buffer, withoutResponse: boolean): Promise<void>;
 
         connect(callback?: (error: Error | undefined) => void): void;
+        connect(options: ConnectOptions, callback?: (error: Error | undefined) => void): void;
         pair(callback: (error: Error | undefined) => void): void;
         pair(kind?: DevicePairingKinds, callback?: (error: Error | undefined) => void): void;
         pair(kind: DevicePairingKinds, protectionLevel: DevicePairingProtectionLevel, callback?: (error: Error | undefined) => void): void;

--- a/lib/dbus/bindings.js
+++ b/lib/dbus/bindings.js
@@ -585,8 +585,11 @@ class DbusBindings extends EventEmitter {
 
   // ---- Connect / disconnect ----
 
-  connect (peripheralUuid, _parameters) {
+  connect (peripheralUuid, parameters) {
     peripheralUuid = normalizeId(peripheralUuid);
+    if (parameters && parameters.mtu !== undefined) {
+      this.emit('warning', 'the mtu connect option is not supported on the dbus backend (BlueZ negotiates the ATT MTU)');
+    }
     this._connect(peripheralUuid).catch(err => {
       // Release the half-open proxy/listener so a retry starts clean. No
       // 'disconnect' — a failed attempt leaves the peripheral in 'error',

--- a/lib/hci-socket/gatt.js
+++ b/lib/hci-socket/gatt.js
@@ -56,6 +56,27 @@ const GATT_SERVER_CHARAC_CFG_UUID = 0x2903;
 const ATT_CID = 0x0004;
 /* eslint-enable no-unused-vars */
 
+// Core Spec Vol 3 Part F 3.2.8: ATT_MTU ranges from the 23 octet default to 517.
+const ATT_MIN_MTU = 23;
+const ATT_MAX_MTU = 517;
+const ATT_DEFAULT_REQUEST_MTU = 256;
+
+// A value the peer cannot honour would be written raw into the request, where a
+// negative or oversized number makes writeUInt16LE throw on the connect path.
+function requestableMtu (desiredMtu) {
+  if (desiredMtu === undefined || desiredMtu === null) {
+    return ATT_DEFAULT_REQUEST_MTU;
+  }
+
+  const mtu = Number(desiredMtu);
+  if (!Number.isInteger(mtu) || mtu < ATT_MIN_MTU || mtu > ATT_MAX_MTU) {
+    debug(`ignoring unusable desired mtu ${desiredMtu}, requesting ${ATT_DEFAULT_REQUEST_MTU}`);
+    return ATT_DEFAULT_REQUEST_MTU;
+  }
+
+  return mtu;
+}
+
 const Gatt = function (address, aclStream, desiredMtu) {
   this._address = address;
   this._aclStream = aclStream;
@@ -67,8 +88,8 @@ const Gatt = function (address, aclStream, desiredMtu) {
   this._currentCommand = null;
   this._commandQueue = [];
 
-  this._mtu = 23;
-  this._desired_mtu = desiredMtu || 256;
+  this._mtu = ATT_MIN_MTU;
+  this._desired_mtu = requestableMtu(desiredMtu);
   this._security = 'low';
 
   this.onAclStreamDataBinded = this.onAclStreamData.bind(this);
@@ -337,7 +358,9 @@ Gatt.prototype.exchangeMtu = function () {
     const opcode = data[0];
 
     if (opcode === ATT_OP_MTU_RESP) {
-      const newMtu = data.readUInt16LE(1);
+      // Core Spec Vol 3 Part F 3.4.2.2: the response carries the peer's own RX MTU,
+      // so ATT_MTU is the smaller of the two.
+      const newMtu = Math.min(this._desired_mtu, data.readUInt16LE(1));
 
       debug(`${this._address}: new MTU is ${newMtu}`);
 

--- a/lib/noble.js
+++ b/lib/noble.js
@@ -84,6 +84,7 @@ class Noble extends NobleEventEmitter {
     this._bindings.on('handleWrite', this._onHandleWrite.bind(this));
     this._bindings.on('handleNotify', this._onHandleNotify.bind(this));
     this._bindings.on('onMtu', this._onMtu.bind(this));
+    this._bindings.on('warning', message => this.emit('warning', message));
   }
 
   _createPeripheral (uuid, address, addressType, connectable, advertisement, rssi, scannable) {

--- a/test/lib/dbus/bindings.test.js
+++ b/test/lib/dbus/bindings.test.js
@@ -633,6 +633,38 @@ describe('dbus/bindings', () => {
       expect(bindings._devices.get('aabbccddeeff').proxy).toBeNull();
     });
 
+    test('warns that the mtu connect option cannot be honoured', async () => {
+      seedDevice();
+      makeProxy(devicePath);
+
+      const bindings = new DbusBindings();
+      const warnings = [];
+      bindings.on('warning', w => warnings.push(w));
+
+      bindings.start();
+      await flush();
+      bindings.connect('aabbccddeeff', { mtu: 23 });
+      await flush();
+
+      expect(warnings.some(w => /mtu connect option is not supported/.test(w))).toBe(true);
+    });
+
+    test('stays quiet when no mtu is requested', async () => {
+      seedDevice();
+      makeProxy(devicePath);
+
+      const bindings = new DbusBindings();
+      const warnings = [];
+      bindings.on('warning', w => warnings.push(w));
+
+      bindings.start();
+      await flush();
+      bindings.connect('aabbccddeeff', { addressType: 'public' });
+      await flush();
+
+      expect(warnings.some(w => /mtu/.test(w))).toBe(false);
+    });
+
     test('a remote drop mid-connect surfaces as connect(error), not disconnect', async () => {
       seedDevice();
       const proxy = makeProxy(devicePath);

--- a/test/lib/hci-socket/gatt.test.js
+++ b/test/lib/hci-socket/gatt.test.js
@@ -755,9 +755,63 @@ describe('hci-socket gatt', () => {
 
     assert.calledOnce(queueCommand);
 
+    // 0x3312 is larger than the requested 256, so ATT_MTU is the requested value.
     queueCommand.callArgWith(1, Buffer.from([0x03, 0x12, 0x33]));
-    assert.calledOnceWithExactly(callback, address, 13074);
-    should(gatt._mtu).equal(13074);
+    assert.calledOnceWithExactly(callback, address, 256);
+    should(gatt._mtu).equal(256);
+  });
+
+  it('exchangeMtu keeps the peer mtu when it is the smaller one', () => {
+    const queueCommand = sinon.spy();
+    const callback = sinon.stub();
+
+    gatt._queueCommand = queueCommand;
+    gatt.on('mtu', callback);
+    gatt.exchangeMtu();
+
+    // 247, the value a peripheral typically answers to a 256 request.
+    queueCommand.callArgWith(1, Buffer.from([0x03, 0xf7, 0x00]));
+    assert.calledOnceWithExactly(callback, address, 247);
+    should(gatt._mtu).equal(247);
+  });
+
+  it('exchangeMtu does not let a peer raise the mtu above the requested one', () => {
+    const requesting = new Gatt(address, aclStream, 23);
+    const queueCommand = sinon.spy();
+    const callback = sinon.stub();
+
+    requesting._queueCommand = queueCommand;
+    requesting.on('mtu', callback);
+    requesting.exchangeMtu();
+
+    should(queueCommand.firstCall.args[0]).deepEqual(Buffer.from([0x02, 0x17, 0x00]));
+
+    queueCommand.callArgWith(1, Buffer.from([0x03, 0xf7, 0x00]));
+    should(requesting._mtu).equal(23);
+  });
+
+  describe('desired mtu validation', () => {
+    it('defaults when no mtu is requested', () => {
+      should(new Gatt(address, aclStream)._desired_mtu).equal(256);
+    });
+
+    it('keeps a usable requested mtu', () => {
+      should(new Gatt(address, aclStream, 23)._desired_mtu).equal(23);
+      should(new Gatt(address, aclStream, 517)._desired_mtu).equal(517);
+    });
+
+    it('falls back to the default for values the peer could never be asked for', () => {
+      for (const unusable of [22, 518, -1, 70000, 1.5, 'abc', NaN, {}]) {
+        should(new Gatt(address, aclStream, unusable)._desired_mtu).equal(256);
+      }
+    });
+
+    it('builds a valid request buffer for every accepted mtu', () => {
+      for (const mtu of [23, 256, 517, -1, 70000, 'abc']) {
+        const built = new Gatt(address, aclStream, mtu);
+        should(() => built.mtuRequest(built._desired_mtu)).not.throw();
+      }
+    });
   });
 
   it('addService', () => {

--- a/test/noble.test.js
+++ b/test/noble.test.js
@@ -48,6 +48,19 @@ describe('noble', () => {
     jest.clearAllMocks();
   });
 
+  it('forwards warnings from the bindings', () => {
+    const received = [];
+    noble.on('warning', message => received.push(message));
+
+    void noble.state; // registering the bindings listeners is deferred until first use
+
+    const registered = mockBindings.on.mock.calls.find(([event]) => event === 'warning');
+    expect(registered).toBeDefined();
+    registered[1]('the mtu connect option is not supported on the dbus backend');
+
+    expect(received).toEqual(['the mtu connect option is not supported on the dbus backend']);
+  });
+
   describe('startScanning', () => {
   
     test('should delegate to binding', () => {


### PR DESCRIPTION
This started as the declaration-only change described in #138, but an adversarial review of it turned up a runtime bug that made the option worth declaring only after it was fixed. The PR now does both.

## The option did not actually work

`exchangeMtu` stored the peer's response verbatim:

```js
const newMtu = data.readUInt16LE(1);
this._mtu = newMtu;
```

Core Spec Vol 3 Part F 3.4.2.2 defines ATT_MTU as the lower of the two RX MTUs, and the response carries the peer's own value rather than one already reduced to what was requested. So requesting *less* than the peer offers had no effect: ask for 23, meet a peripheral answering 247, and the link used 247. This stayed invisible because the common case requests 256 and peripherals answer below it, so the peer's value was already the smaller one — every capture I have looks correct for that reason alone.

Fixed with `Math.min(this._desired_mtu, ...)`. For anyone requesting the 256 default against a peripheral answering below it, behaviour is unchanged.

## The requested value was unvalidated

It reached `writeUInt16LE` raw, so a typed-legal `number` could break a connection:

```
23     -> ok
517    -> ok
5000   -> sent unchanged, outside the ATT range
70000  -> throws ERR_OUT_OF_RANGE
'abc'  -> silently becomes MTU 0
-1     -> throws ERR_OUT_OF_RANGE
```

`exchangeMtu` runs from the connection-complete path, so a throw there is not recoverable for that connect. It is now range checked once in one place, and anything unusable falls back to the 256 default with a debug line rather than being sent or thrown.

## Declarations

`ConnectOptions` gains `mtu`, and `Peripheral.connect` / `Peripheral.connectAsync` gain the options parameter they have always accepted at runtime (`lib/peripheral.js:36-58` already handles both `(callback)` and `(options, callback)`). The callback-only overload is declared first so existing calls keep resolving to it, and `mtu` is optional, so nothing that compiles today stops compiling.

The doc records that only the HCI bindings honour it, and why: CoreBluetooth exposes `maximumWriteValueLengthForType:`, WinRT exposes `GattSession.MaxPduSize`, and BlueZ exposes nothing equivalent over D-Bus — all three negotiate the MTU themselves and only report the result, so there is nothing for the other backends to request. If you would rather the other backends warned when handed an option they cannot honour, the way `setScanParameters` does on dbus, I am happy to add that; I left it out here to keep this off the same file as #137.

## One existing test changed

`exchangeMtu ATT_OP_MTU_RESP` asserted that a peer answering `0x3312` raised the MTU to 13074. That is the behaviour being corrected, so it now expects the requested 256. Flagging it explicitly rather than burying it in the diff.

## Verification

Six new tests: peer smaller than requested, peer larger than requested, the request buffer for an explicit 23, the default when nothing is asked, accepted boundary values, and rejection of unusable ones. I checked each production hunk by reverting it and confirming a named test fails — `Math.min`, the validation call, the range bounds and the integer check each have a test that goes red without them.

Local full suite: 19 suites, 828 passed, 1 expected skip. Lint clean. `tsc --noEmit --strict` on `index.d.ts` is clean.

Not verified on hardware. The `Math.min` change only alters behaviour when a peripheral answers above the requested MTU, which I have no capture of.

Refs #138

---

## Second commit: not silently ignoring it elsewhere

Since this makes `mtu` a documented, typed option while only one backend can honour it, the dbus backend now warns instead of dropping it, using the same shape it already has for `setScanParameters`, `setAddress` and `broadcast`.

While wiring that up I found the pattern was not reaching anyone: `warning` is the one bindings event `Noble._registerListeners` does not forward, so the five warnings this backend already emits went to an object no consumer holds. That is forwarded now, which also brings them under the `console.warn` handler the Noble constructor installs. If you would rather not change what reaches consumers, say so and I will drop that hunk — the warning itself is then cosmetic, so I would drop both.

CoreBluetooth and WinRT cannot do the same: their bindings are native, with no JavaScript seam at the connect call.

Three more tests, each mutation-proven: the warning fires for `{ mtu }`, stays quiet without it, and Noble forwards a bindings warning.

Merges cleanly with #137, which touches a different part of the same file — checked with `git merge-tree`, not assumed.
